### PR TITLE
:bug: Use simplified github urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/dashevo/wallet-lib#readme",
   "dependencies": {
-    "@dashevo/dapi-sdk": "git+ssh://git@github.com/dashevo/dapi-client.git",
-    "@dashevo/dashcore-lib": "git+ssh://git@github.com/dashevo/dashcore-lib.git#evo",
+    "@dashevo/dapi-sdk": "github:dashevo/dapi-client",
+    "@dashevo/dashcore-lib": "github:dashevo/dashcore-lib.git#evo",
     "@dashevo/dashcore-mnemonic": "^1.5.0",
     "axios": "^0.18.0",
     "localforage": "^1.7.2",


### PR DESCRIPTION
This Github URL format gives better Travis and npm compatibility and removes the need to add github rules to transform repo URLs from ssh to https or vice versa