### PR TITLE
Feat : Allow to load a wallet from an Extended Public Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Miscellaneous :
 - [x] Persistance interface
     - [x] In-mem support
     - [ ] DB support
+- [x] HDWallet : Create from a HDPublicKey
 - [x] HDWallet : Create a wallet / generate a new mnemonic
 - [x] HDWallet : Validate mnemonic (BIP39)
 - [x] HDWallet : Create an account

--- a/docs/wallet.md
+++ b/docs/wallet.md
@@ -32,11 +32,13 @@ const Wallet = new Wallet(opts);
 
 > **passphrase** : String(def: null) : Set the passphrase to a mnemonic
 
-> **mnemonic** : String : When set will init the wallet from it.
+> **mnemonic** : String|Mnemonic : When set will init the wallet from it.
 
-> **seed** : String : When set will init the wallet from it.
+> **seed** : String|HDPrivateKey : When set will init the wallet from it.
 
-> **privateKey** : String : When set will init the wallet from it.
+> **privateKey** : String|PrivateKey : When set will init the wallet from it.
+
+> **HDExtPublicKey** : String|HDPublicKey : When set will init the wallet from it.
 
 > **network** : String(def: testnet) : Will be used to set the network for various crypto manipulation (genAddr)
 

--- a/examples/wallet-dapi-fromHDPubKey.js
+++ b/examples/wallet-dapi-fromHDPubKey.js
@@ -1,0 +1,33 @@
+const { Wallet, EVENTS } = require('../src');
+const DAPIClient = require('@dashevo/dapi-client');
+
+const transport = new DAPIClient({ seeds: [{ ip: '54.187.113.35', port: 3000 }] });
+const wallet = new Wallet({
+  HDExtPublicKey: 'tpubDFLd6pf4VJ72YFdAVp5sXWiszJhGM4yhXnAYkXagFf2fS3NiTU6rwQsxkMiVPKqeGBTWC2DZ8ZicuT49jnKwMEr6gAT4f83YqB3dnujarD3',
+  network: 'testnet',
+  transport,
+});
+
+
+const account = wallet.getAccount();
+
+
+const start = async () => {
+  console.log('Balance Conf', await account.getBalance(false, false));
+  console.log('Balance Unconf', await account.getBalance(true, false));
+  console.log('New Addr', await account.getUnusedAddress().address);
+  //
+  // const tx = account.createTransaction({recipient:'yhvXpqQjfN9S4j5mBKbxeGxiETJrrLETg5', amount:5.74});
+  // console.log(tx.toString());
+  // const bdc = await account.broadcastTransaction(tx.toString());
+  // console.log(bdc)
+
+};
+
+account.events.on(EVENTS.GENERATED_ADDRESS, (info) => { console.log('GENERATED_ADDRESS'); });
+account.events.on(EVENTS.BALANCE_CHANGED, (info) => { console.log('Balance Changed', info, info.delta); });
+account.events.on(EVENTS.UNCONFIRMED_BALANCE_CHANGED, (info) => { console.log('UNCONFIRMED_BALANCE_CHANGED', info); });
+account.events.on(EVENTS.READY, start);
+account.events.on(EVENTS.BLOCKHEIGHT_CHANGED, info => console.log('BLOCKHEIGHT_CHANGED:', info));
+account.events.on(EVENTS.PREFETCHED, () => { console.log(EVENTS.PREFETCHED); });
+account.events.on(EVENTS.DISCOVERY_STARTED, () => console.log(EVENTS.PREFETCHED));

--- a/src/Account/Account.js
+++ b/src/Account/Account.js
@@ -62,6 +62,7 @@ class Account {
       getAddress,
       getAddresses,
       getBalance,
+      getBIP44Path,
       getDAP,
       getPlugin,
       getPrivateKeys,
@@ -83,7 +84,7 @@ class Account {
     this.injectDefaultPlugins = _.has(opts, 'injectDefaultPlugins') ? opts.injectDefaultPlugins : defaultOptions.injectDefaultPlugins;
     this.allowSensitiveOperations = _.has(opts, 'allowSensitiveOperations') ? opts.allowSensitiveOperations : defaultOptions.allowSensitiveOperations;
 
-    this.type = wallet.type;
+    this.walletType = wallet.walletType;
     this.offlineMode = wallet.offlineMode;
 
     const accountIndex = _.has(opts, 'accountIndex') ? opts.accountIndex : wallet.accounts.length;
@@ -103,14 +104,21 @@ class Account {
     this.store = wallet.storage.store;
     this.storage = wallet.storage;
 
-    if (this.type === WALLET_TYPES.HDWALLET) {
+    if (this.walletType === WALLET_TYPES.HDWALLET) {
       this.storage.importAccounts({
         label: this.label,
         path: this.BIP44PATH,
         network: this.network,
       }, this.walletId);
     }
-    if (this.type === WALLET_TYPES.SINGLE_ADDRESS) {
+    if (this.walletType === WALLET_TYPES.HDEXTPUBLIC) {
+      this.storage.importSingleAddress({
+        label: this.label,
+        path: '/0',
+        network: this.network,
+      }, this.walletId);
+    }
+    if (this.walletType === WALLET_TYPES.SINGLE_ADDRESS) {
       this.storage.importSingleAddress({
         label: this.label,
         path: '0',

--- a/src/Account/_initializeAccount.js
+++ b/src/Account/_initializeAccount.js
@@ -20,7 +20,7 @@ async function _initializeAccount(account, userUnsafePlugins) {
         account.injectPlugin(ChainWorker, true);
       }
 
-      if (account.type === WALLET_TYPES.HDWALLET) {
+      if ([WALLET_TYPES.HDWALLET, WALLET_TYPES.HDEXTPUBLIC].includes(account.walletType)) {
         // Ideally we should move out from worker to event based
         account.injectPlugin(BIP44Worker, true);
       }

--- a/src/Account/getAddress.js
+++ b/src/Account/getAddress.js
@@ -12,7 +12,7 @@ const getTypePathFromWalletType = (walletType, addressType = 'external', index, 
       break;
     case WALLET_TYPES.HDEXTPUBLIC:
       type = 'external';
-      path = `${BIP44PATH}/${addressTypeIndex}/${index}`
+      path = `${BIP44PATH}/${addressTypeIndex}/${index}`;
       break;
     case WALLET_TYPES.SINGLE_ADDRESS:
     default:

--- a/src/Account/getAddress.js
+++ b/src/Account/getAddress.js
@@ -1,5 +1,26 @@
 const { WALLET_TYPES } = require('../CONSTANTS');
 
+const getTypePathFromWalletType = (walletType, addressType = 'external', index, BIP44PATH) => {
+  let type;
+  let path;
+
+  const addressTypeIndex = (addressType === 'external') ? 0 : 1;
+  switch (walletType) {
+    case WALLET_TYPES.HDWALLET:
+      type = addressType;
+      path = `${BIP44PATH}/${addressTypeIndex}/${index}`;
+      break;
+    case WALLET_TYPES.HDEXTPUBLIC:
+      type = 'external';
+      path = `${BIP44PATH}/${addressTypeIndex}/${index}`
+      break;
+    case WALLET_TYPES.SINGLE_ADDRESS:
+    default:
+      type = 'misc';
+      path = '0';
+  }
+  return { type, path };
+};
 /**
  * Get a specific addresss based on the index and type of address.
  * @param index - The index on the type
@@ -7,20 +28,10 @@ const { WALLET_TYPES } = require('../CONSTANTS');
  * @return <AddressInfo>
  */
 function getAddress(index = 0, _type = 'external') {
-  // eslint-disable-next-line no-nested-ternary
-  // console.log(index, _type)
-  const type = (this.type === WALLET_TYPES.SINGLE_ADDRESS)
-    ? 'misc'
-    : ((_type) || 'external');
-
-  // eslint-disable-next-line no-nested-ternary
-  const path = (type === 'misc')
-    ? '0'
-    : ((_type === 'external') ? `${this.BIP44PATH}/0/${index}` : `${this.BIP44PATH}/1/${index}`);
+  const { type, path } = getTypePathFromWalletType(this.walletType, _type, index, this.BIP44PATH);
 
   const { wallets } = this.storage.getStore();
   const addressType = wallets[this.walletId].addresses[type];
-  // console.log(type, path)
   // console.log(addressType, path)
   return (addressType[path]) ? addressType[path] : this.generateAddress(path);
 }

--- a/src/Account/getAddresses.js
+++ b/src/Account/getAddresses.js
@@ -6,10 +6,10 @@ const { WALLET_TYPES } = require('../CONSTANTS');
  * @return {Object} address - All address matching the type
  */
 function getAddresses(_type = 'external') {
-  const type = (this.type === WALLET_TYPES.SINGLE_ADDRESS)
+  const walletType = (this.walletType === WALLET_TYPES.SINGLE_ADDRESS)
     ? 'misc'
     : ((_type) || 'external');
   const store = this.storage.getStore();
-  return store.wallets[this.walletId].addresses[type];
+  return store.wallets[this.walletId].addresses[walletType];
 }
 module.exports = getAddresses;

--- a/src/CONSTANTS.js
+++ b/src/CONSTANTS.js
@@ -35,6 +35,7 @@ const CONSTANTS = {
   WALLET_TYPES: {
     SINGLE_ADDRESS: 'single_address',
     HDWALLET: 'hdwallet',
+    HDEXTPUBLIC: 'hdextpublic',
   },
   // List of account function and properties that can be injected in a plugin
   INJECTION_LISTS: {

--- a/src/Wallet/Wallet.d.ts
+++ b/src/Wallet/Wallet.d.ts
@@ -1,4 +1,4 @@
-import {Mnemonic,PrivateKey,Strategy, Network, Plugins} from "../types";
+import {Mnemonic,PrivateKey, HDPublicKey, Strategy, Network, Plugins} from "../types";
 import {Account} from "../Account/Account";
 
 export declare class Wallet {
@@ -9,6 +9,7 @@ export declare class Wallet {
     exportWallet():Mnemonic["toString"];
     fromMnemonic(Mnemonic):void;
     fromPrivateKey(PrivateKey):void;
+    fromHDPubKey(HDPublicKey):void;
     fromSeed(seed):void;
     generateNewWalletId():void;
     getAccount(accOptions: Wallet.getAccOptions): Account;

--- a/src/Wallet/Wallet.js
+++ b/src/Wallet/Wallet.js
@@ -24,6 +24,7 @@ const exportWallet = require('./exportWallet');
 const fromMnemonic = require('./fromMnemonic');
 const fromPrivateKey = require('./fromPrivateKey');
 const fromSeed = require('./fromSeed');
+const fromHDExtPublicKey = require('./fromHDExtPublicKey');
 const generateNewWalletId = require('./generateNewWalletId');
 const updateNetwork = require('./updateNetwork');
 
@@ -52,6 +53,7 @@ class Wallet {
       fromMnemonic,
       fromSeed,
       fromPrivateKey,
+      fromHDExtPublicKey,
       generateNewWalletId,
       updateNetwork,
       exportWallet,
@@ -73,6 +75,8 @@ class Wallet {
       this.fromSeed(opts.seed);
     } else if ('privateKey' in opts) {
       this.fromPrivateKey(opts.privateKey);
+    } else if ('HDExtPublicKey' in opts) {
+      this.fromHDExtPublicKey(opts.HDExtPublicKey);
     } else {
       this.fromMnemonic(generateNewMnemonic());
     }

--- a/src/Wallet/createAccount.js
+++ b/src/Wallet/createAccount.js
@@ -15,7 +15,7 @@ function createAccount(accountOpts) {
 
   const { injectDefaultPlugins, plugins, allowSensitiveOperations } = this;
   const baseOpts = { injectDefaultPlugins, allowSensitiveOperations, plugins };
-  if (this.type === WALLET_TYPES.SINGLE_ADDRESS) { baseOpts.privateKey = this.privateKey; }
+  if (this.walletType === WALLET_TYPES.SINGLE_ADDRESS) { baseOpts.privateKey = this.privateKey; }
   const opts = Object.assign(baseOpts, accountOpts);
   return new Account(this, opts);
 }

--- a/src/Wallet/exportWallet.js
+++ b/src/Wallet/exportWallet.js
@@ -14,10 +14,13 @@ module.exports = function exportWallet(toHDPrivateKey = false) {
   if (toHDPrivateKey) {
     return this.HDPrivateKey;
   }
-  switch (this.type) {
+  switch (this.walletType) {
     case WALLET_TYPES.SINGLE_ADDRESS:
       if (!this.privateKey) throw new Error('No privateKey to export');
       return this.privateKey;
+    case WALLET_TYPES.HDEXTPUBLIC:
+      if (!this.HDExtPublicKey) throw new Error('No publicKey to export');
+      return this.HDExtPublicKey.toString();
     case WALLET_TYPES.HDWALLET:
       return exportMnemonic(this.mnemonic);
     default:

--- a/src/Wallet/fromHDExtPublicKey.js
+++ b/src/Wallet/fromHDExtPublicKey.js
@@ -1,7 +1,7 @@
+const Dashcore = require('@dashevo/dashcore-lib');
 const { is } = require('../utils/index');
 const KeyChain = require('../KeyChain');
 const { WALLET_TYPES } = require('../CONSTANTS');
-const Dashcore = require('@dashevo/dashcore-lib');
 
 
 const normalizeHDPubKey = key => (is.string(key) ? Dashcore.HDPublicKey(key) : key);
@@ -14,6 +14,6 @@ module.exports = function fromHDPublicKey(_hdPublicKey) {
   this.walletType = WALLET_TYPES.HDEXTPUBLIC;
   this.mnemonic = null;
   const hdPublicKey = normalizeHDPubKey(_hdPublicKey);
-  this.HDExtPublicKey = hdPublicKey
+  this.HDExtPublicKey = hdPublicKey;
   this.keyChain = new KeyChain({ HDPublicKey: hdPublicKey });
 };

--- a/src/Wallet/fromHDExtPublicKey.js
+++ b/src/Wallet/fromHDExtPublicKey.js
@@ -1,0 +1,19 @@
+const { is } = require('../utils/index');
+const KeyChain = require('../KeyChain');
+const { WALLET_TYPES } = require('../CONSTANTS');
+const Dashcore = require('@dashevo/dashcore-lib');
+
+
+const normalizeHDPubKey = key => (is.string(key) ? Dashcore.HDPublicKey(key) : key);
+/**
+ * Will set a wallet to work with a on readonly mode from a HDPublicKey
+ * @param HDPublicKey
+ */
+module.exports = function fromHDPublicKey(_hdPublicKey) {
+  if (!is.HDPublicKey(_hdPublicKey)) throw new Error('Expected a valid HDExtPublic key (typeof HDExtPublicKey or String)');
+  this.walletType = WALLET_TYPES.HDEXTPUBLIC;
+  this.mnemonic = null;
+  const hdPublicKey = normalizeHDPubKey(_hdPublicKey);
+  this.HDExtPublicKey = hdPublicKey
+  this.keyChain = new KeyChain({ HDPublicKey: hdPublicKey });
+};

--- a/src/Wallet/fromMnemonic.js
+++ b/src/Wallet/fromMnemonic.js
@@ -14,8 +14,8 @@ module.exports = function fromMnemonic(mnemonic) {
     throw new Error('Expected a valid mnemonic (typeof String or Mnemonic)');
   }
   const trimmedMnemonic = mnemonic.toString().trim();
-  this.type = WALLET_TYPES.HDWALLET;
+  this.walletType = WALLET_TYPES.HDWALLET;
   this.mnemonic = trimmedMnemonic; // todo : What about without this ?
   this.HDPrivateKey = mnemonicToHDPrivateKey(trimmedMnemonic, this.network, this.passphrase);
-  this.keyChain = new KeyChain({ HDRootKey: this.HDPrivateKey });
+  this.keyChain = new KeyChain({ HDPrivateKey: this.HDPrivateKey });
 };

--- a/src/Wallet/fromPrivateKey.js
+++ b/src/Wallet/fromPrivateKey.js
@@ -9,7 +9,7 @@ const { WALLET_TYPES } = require('../CONSTANTS');
  */
 module.exports = function fromPrivateKey(privateKey) {
   if (!is.privateKey(privateKey)) throw new Error('Expected a valid private key (typeof PrivateKey or String)');
-  this.type = WALLET_TYPES.SINGLE_ADDRESS;
+  this.walletType = WALLET_TYPES.SINGLE_ADDRESS;
   this.mnemonic = null;
   this.privateKey = privateKey;
   this.keyChain = new KeyChain({ privateKey });

--- a/src/Wallet/fromSeed.js
+++ b/src/Wallet/fromSeed.js
@@ -11,8 +11,8 @@ const { WALLET_TYPES } = require('../CONSTANTS');
  */
 module.exports = function fromSeed(seed) {
   if (!is.seed(seed)) throw new Error('Expected a valid seed (typeof HDPrivateKey or String)');
-  this.type = WALLET_TYPES.HDWALLET;
+  this.walletType = WALLET_TYPES.HDWALLET;
   this.mnemonic = null;
   this.HDPrivateKey = seed;
-  this.keyChain = new KeyChain({ HDRootKey: seed });
+  this.keyChain = new KeyChain({ HDPrivateKey: seed });
 };

--- a/src/Wallet/generateNewWalletId.js
+++ b/src/Wallet/generateNewWalletId.js
@@ -6,12 +6,16 @@ const { WALLET_TYPES } = require('../CONSTANTS');
  * @return walletId
  */
 module.exports = function generateNewWalletId() {
-  const { type } = this;
+  const { walletType } = this;
   const errorMessageBase = 'Cannot generate a walletId';
-  switch (type) {
+  switch (walletType) {
     case WALLET_TYPES.SINGLE_ADDRESS:
       if (!this.privateKey) throw new Error(`${errorMessageBase} : No privateKey found`);
       this.walletId = mnemonicToWalletId(this.privateKey);
+      break;
+    case WALLET_TYPES.HDEXTPUBLIC:
+      if (!this.HDExtPublicKey) throw new Error(`${errorMessageBase} : No HDExtPublicKey found`);
+      this.walletId = mnemonicToWalletId(this.HDExtPublicKey);
       break;
     case WALLET_TYPES.HDWALLET:
     default:

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,6 +5,9 @@ export declare type Mnemonic<T extends object = object> = T & {
 export declare type PrivateKey<T extends object = object> = T & {
     toString(): string;
 };
+export declare type HDPublicKey<T extends object = object> = T & {
+    toString(): string;
+};
 export declare type PublicKey<T extends object = object> = T & {
     toString(): string;
 };

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 // Todo : Some validators here are really proto type of methods, urgent impr is needed here.
 const {
-  PrivateKey, HDPrivateKey, Transaction, Mnemonic, Networks, Address,
+  PrivateKey, HDPrivateKey, HDPublicKey, Transaction, Mnemonic, Networks, Address,
 } = require('@dashevo/dashcore-lib');
 
 const is = {
@@ -28,9 +28,10 @@ const is = {
   network: network => !is.undefOrNull(network) && (is.string(network) || (network.constructor && network.constructor.name === Networks.livenet.constructor.name)),
   privateKey: pKey => !is.undefOrNull(pKey) && (pKey.constructor.name === PrivateKey.name || (is.string(pKey) && PrivateKey.isValid(pKey))),
   HDPrivateKey: hdKey => !is.undefOrNull(hdKey) && (hdKey.constructor.name === HDPrivateKey.name || (is.string(hdKey) && HDPrivateKey.isValidSerialized(hdKey))),
+  HDPublicKey: hdKey => !is.undefOrNull(hdKey) && (hdKey.constructor.name === HDPublicKey.name || (is.string(hdKey) && HDPublicKey.isValidSerialized(hdKey))),
   seed: seed => !is.undefOrNull(seed) && (is.string(seed) || is.privateKey(seed) || is.HDPrivateKey(seed) || is.mnemonic(seed)),
   address: addr => !is.undefOrNull(addr) && (is.string(addr) || addr.constructor.name === Address.name),
-  addressObj: addrObj => !is.undefOrNull(addrObj) && ((!is.undefOrNull(addrObj.address) && addrObj.address.constructor.name === Address.name) || (is.string(addrObj.address) && is.string(addrObj.path))),
+  addressObj: addrObj => !is.undefOrNull(addrObj) && ((!is.undefOrNull(addrObj.address) && addrObj.address.constructor.name === Address.name) || (is.string(addrObj.address) && (is.string(addrObj.path)))),
   transactionObj: tx => is.obj(tx) && is.txid(tx.txid) && tx.vin && is.arr(tx.vin) && tx.vout && is.arr(tx.vout),
   dashcoreTransaction: tx => is.type(tx, Transaction.name),
   feeRate: feeRate => is.obj(feeRate) && is.string(feeRate.type) && is.int(feeRate.value),

--- a/test/Account/createTransaction.js
+++ b/test/Account/createTransaction.js
@@ -114,7 +114,7 @@ describe('Account - createTransaction', () => {
       getPrivateKeys,
       strategy: simpleDescendingAccumulator ,
       generateAddress,
-      keyChain: new KeyChain({ HDRootKey: mnemonicToHDPrivateKey(duringDevelopMnemonic, 'testnet', '') }),
+      keyChain: new KeyChain({ HDPrivateKey: mnemonicToHDPrivateKey(duringDevelopMnemonic, 'testnet', '') }),
       storage,
       events: { emit: _.noop },
     };
@@ -168,7 +168,7 @@ describe('Account - createTransaction', () => {
       getPrivateKeys,
       generateAddress,
       strategy: () => { throw new Error(); }, // Ensure it call the passed option
-      keyChain: new KeyChain({ HDRootKey: mnemonicToHDPrivateKey(duringDevelopMnemonic, 'testnet', '') }),
+      keyChain: new KeyChain({ HDPrivateKey: mnemonicToHDPrivateKey(duringDevelopMnemonic, 'testnet', '') }),
       storage,
       events: { emit: _.noop },
     };

--- a/test/Account/getUnusedAddress.js
+++ b/test/Account/getUnusedAddress.js
@@ -21,8 +21,8 @@ describe('Account - getUnusedAddress', () => {
         emit: _ => (_),
       },
       keyChain: new KeyChain({
-        type: 'HDRootKey',
-        HDRootKey: Dashcore.HDPrivateKey(HDRootKeyMockedStore),
+        type: 'HDPrivateKey',
+        HDPrivateKey: Dashcore.HDPrivateKey(HDRootKeyMockedStore),
       }),
       BIP44PATH: 'm/44\'/1\'/0\'',
       walletId: '5061b8276c',

--- a/test/Wallet/Wallet.js
+++ b/test/Wallet/Wallet.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const knifeMnemonic = require('../fixtures/knifeeasily');
+const gatherSailMnemonic = require('../fixtures/gathersail');
 const fluidMnemonic = require('../fixtures/fluidDepth');
 const cR4t6ePrivateKey = require('../fixtures/cR4t6e_pk');
 const { WALLET_TYPES } = require('../../src/CONSTANTS');
@@ -14,12 +15,12 @@ const mocks = {
 describe('Wallet - class', () => {
   it('should create a wallet without parameters', () => {
     const wallet1 = new Wallet(mocks);
-    expect(wallet1.type).to.be.equal(WALLET_TYPES.HDWALLET);
+    expect(wallet1.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
     expect(Dashcore.Mnemonic(wallet1.mnemonic).toString()).to.be.equal(wallet1.mnemonic);
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
-    expect(wallet1.keyChain.type).to.be.deep.equal('HDRootKey');
+    expect(wallet1.keyChain.type).to.be.deep.equal('HDPrivateKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
     expect(wallet1.injectDefaultPlugins).to.be.deep.equal(true);
@@ -27,7 +28,7 @@ describe('Wallet - class', () => {
     expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
 
     const wallet2 = new Wallet(mocks);
-    expect(wallet2.type).to.be.equal(WALLET_TYPES.HDWALLET);
+    expect(wallet2.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
     expect(Dashcore.Mnemonic(wallet2.mnemonic).toString()).to.be.equal(wallet2.mnemonic);
     expect(wallet2.mnemonic).to.be.not.equal(wallet1.mnemonic);
     expect(wallet2.network).to.be.deep.equal(Dashcore.Networks.testnet);
@@ -41,13 +42,13 @@ describe('Wallet - class', () => {
   });
   it('should create a wallet with mnemonic', () => {
     const wallet1 = new Wallet(Object.assign({ mnemonic: knifeMnemonic.mnemonic }, mocks));
-    expect(wallet1.type).to.be.equal(WALLET_TYPES.HDWALLET);
+    expect(wallet1.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
     expect(Dashcore.Mnemonic(wallet1.mnemonic).toString()).to.be.equal(wallet1.mnemonic);
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
     expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
-    expect(wallet1.keyChain.type).to.be.deep.equal('HDRootKey');
+    expect(wallet1.keyChain.type).to.be.deep.equal('HDPrivateKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
     expect(wallet1.injectDefaultPlugins).to.be.deep.equal(true);
@@ -55,7 +56,7 @@ describe('Wallet - class', () => {
 
     const opts2 = Object.assign({ mnemonic: knifeMnemonic.mnemonic, network: 'livenet' }, mocks);
     const wallet2 = new Wallet(opts2);
-    expect(wallet2.type).to.be.equal(WALLET_TYPES.HDWALLET);
+    expect(wallet2.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
     expect(wallet2.network).to.be.deep.equal(Dashcore.Networks.mainnet);
     expect(Dashcore.Mnemonic(wallet2.mnemonic).toString()).to.be.equal(wallet2.mnemonic);
     expect(wallet2.walletId).to.be.equal(knifeMnemonic.walletIdMainnet);
@@ -68,13 +69,13 @@ describe('Wallet - class', () => {
   });
   it('should create a wallet with HDPrivateKey', () => {
     const wallet1 = new Wallet(Object.assign({ seed: knifeMnemonic.HDRootPrivateKeyTestnet, network: 'testnet' }, mocks));
-    expect(wallet1.type).to.be.equal(WALLET_TYPES.HDWALLET);
+    expect(wallet1.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
     expect(wallet1.mnemonic).to.be.equal(null);
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
     expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
-    expect(wallet1.keyChain.type).to.be.deep.equal('HDRootKey');
+    expect(wallet1.keyChain.type).to.be.deep.equal('HDPrivateKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
     expect(wallet1.injectDefaultPlugins).to.be.deep.equal(true);
@@ -83,9 +84,26 @@ describe('Wallet - class', () => {
       wallet1.disconnect();
     });
   });
+  it('should create a wallet with HDExtPublicKey', () => {
+    const wallet1 = new Wallet(Object.assign({ HDExtPublicKey: gatherSailMnemonic.testnet.external.hdpubkey, network: 'testnet' }, mocks));
+    expect(wallet1.walletType).to.be.equal(WALLET_TYPES.HDEXTPUBLIC);
+    expect(wallet1.mnemonic).to.be.equal(null);
+
+    expect(wallet1.plugins).to.be.deep.equal({});
+    expect(wallet1.accounts).to.be.deep.equal([]);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.keyChain.type).to.be.deep.equal('HDPublicKey');
+    expect(wallet1.passphrase).to.be.deep.equal(null);
+    expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
+    expect(wallet1.injectDefaultPlugins).to.be.deep.equal(true);
+    expect(wallet1.walletId).to.be.equal(gatherSailMnemonic.testnet.external.walletId);
+    wallet1.storage.events.on('CONFIGURED', () => {
+      wallet1.disconnect();
+    });
+  });
   it('should create a wallet with PrivateKey', () => {
     const wallet1 = new Wallet(Object.assign({ privateKey: cR4t6ePrivateKey.privateKey, network: 'testnet' }, mocks));
-    expect(wallet1.type).to.be.equal(WALLET_TYPES.SINGLE_ADDRESS);
+    expect(wallet1.walletType).to.be.equal(WALLET_TYPES.SINGLE_ADDRESS);
     expect(wallet1.mnemonic).to.be.equal(null);
 
     expect(wallet1.plugins).to.be.deep.equal({});

--- a/test/Wallet/exportWallet.js
+++ b/test/Wallet/exportWallet.js
@@ -7,8 +7,8 @@ const knifeMnemonic = require('../fixtures/knifeeasily');
 describe('Wallet - export Wallet', () => {
   it('should indicate on missing data', () => {
     const mockOpts1 = { };
-    const mockOpts2 = { type: WALLET_TYPES.SINGLE_ADDRESS };
-    const mockOpts3 = { type: WALLET_TYPES.HDWALLET };
+    const mockOpts2 = { walletType: WALLET_TYPES.SINGLE_ADDRESS };
+    const mockOpts3 = { walletType: WALLET_TYPES.HDWALLET };
 
     const exceptedException1 = 'Trying to export from an unknown wallet type';
     const exceptedException2 = 'No privateKey to export';
@@ -19,11 +19,11 @@ describe('Wallet - export Wallet', () => {
   });
   it('should export a privateKey', () => {
     const mockOpts1 = {
-      type: WALLET_TYPES.SINGLE_ADDRESS,
+      walletType: WALLET_TYPES.SINGLE_ADDRESS,
       privateKey: cR4t6ePrivateKey.privateKey,
     };
     const mockOpts2 = {
-      type: WALLET_TYPES.HDWALLET,
+      walletType: WALLET_TYPES.HDWALLET,
       mnemonic: knifeMnemonic.mnemonic,
     };
     expect(exportWallet.call(mockOpts1)).to.equal(cR4t6ePrivateKey.privateKey);

--- a/test/Wallet/fromHDPublicKey.js
+++ b/test/Wallet/fromHDPublicKey.js
@@ -1,0 +1,74 @@
+const Dashcore = require('@dashevo/dashcore-lib');
+const { expect } = require('chai');
+const Wallet = require('../../src/Wallet/Wallet');
+const fromHDPublicKey = require('../../src/Wallet/fromHDExtPublicKey');
+const gatherSail = require('../fixtures/gathersail');
+const { WALLET_TYPES } = require('../../src/CONSTANTS');
+/**
+ * Theses first set of data labeled gatherSail correspond to the following mnemonic:
+ * gather sail face invite together focus waste barely excuse slide harbor hint
+ *
+ *
+ * @type {string}
+ */
+describe('Wallet - HDExtPublicKey', () => {
+  const gatherTestnet = gatherSail.testnet;
+  it('should detect wrong parameters', () => {
+    const mockOpts1 = { };
+    const exceptedException1 = 'Expected a valid HDExtPublic key (typeof HDExtPublicKey or String)';
+    expect(() => fromHDPublicKey.call(mockOpts1)).to.throw(exceptedException1);
+    expect(() => fromHDPublicKey.call(mockOpts1, gatherTestnet.external.hdprivkey)).to.throw(exceptedException1);
+    expect(() => fromHDPublicKey.call(mockOpts1, gatherTestnet.mnemonic)).to.throw(exceptedException1);
+    expect(() => fromHDPublicKey.call(mockOpts1, 'cR4t6evwVZoCp1JsLk4wURK4UmBCZzZotNzn9T1mhBT19SH9JtNt')).to.throw(exceptedException1);
+  });
+  it('should work from a valid HDExtPubKey', () => {
+    const mockOpts1 = { };
+    fromHDPublicKey.call(mockOpts1, gatherTestnet.external.hdpubkey);
+
+    expect(mockOpts1.walletType).to.equal(WALLET_TYPES.HDEXTPUBLIC);
+    expect(mockOpts1.mnemonic).to.equal(null);
+    expect(mockOpts1.HDExtPublicKey.toString()).to.equal(gatherTestnet.external.hdpubkey);
+    expect(new Dashcore.HDPublicKey(mockOpts1.HDExtPublicKey)).to.equal(mockOpts1.HDExtPublicKey);
+    expect(mockOpts1.keyChain.type).to.equal('HDPublicKey');
+    expect(mockOpts1.keyChain.HDPublicKey).to.deep.equal(Dashcore.HDPublicKey(gatherTestnet.external.hdpubkey));
+    expect(mockOpts1.keyChain.keys).to.deep.equal({});
+  });
+  it('should work from a HDExtPubKey', () => {
+    const wallet1 = new Wallet(
+      { HDExtPublicKey: gatherTestnet.external.hdpubkey, offlineMode: true },
+    );
+
+    expect(wallet1.walletType).to.be.equal(WALLET_TYPES.HDEXTPUBLIC);
+    expect(wallet1.mnemonic).to.be.equal(null);
+
+    expect(wallet1.plugins).to.be.deep.equal({});
+    expect(wallet1.accounts).to.be.deep.equal([]);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.keyChain.type).to.be.deep.equal('HDPublicKey');
+    expect(wallet1.passphrase).to.be.deep.equal(null);
+    expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
+    expect(wallet1.injectDefaultPlugins).to.be.deep.equal(true);
+    expect(wallet1.walletId).to.be.equal(gatherTestnet.external.walletId);
+
+    expect(wallet1.exportWallet()).to.be.equal(gatherTestnet.external.hdpubkey);
+
+    const account = wallet1.getAccount();
+    const unusedAddress = account.getUnusedAddress();
+    const expectedUnused = {
+      path: "m/44'/1'/0'/0/0",
+      index: 0,
+      address: 'yNJ3xxTXXBBf39VfMBbBuLH2k57uAwxBxj',
+      transactions: [],
+      balanceSat: 0,
+      unconfirmedBalanceSat: 0,
+      utxos: {},
+      fetchedLast: 0,
+      used: false,
+    };
+    expect(unusedAddress).to.deep.equal(expectedUnused);
+
+    wallet1.storage.events.on('CONFIGURED', () => {
+      wallet1.disconnect();
+    });
+  });
+});

--- a/test/Wallet/fromMnemonic.js
+++ b/test/Wallet/fromMnemonic.js
@@ -13,23 +13,23 @@ describe('Wallet - fromMnemonic', () => {
   it('should set wallet from mnemonic', () => {
     const self1 = {};
     fromMnemonic.call(self1, knifeFixture.mnemonic);
-    expect(self1.type).to.equal(WALLET_TYPES.HDWALLET);
+    expect(self1.walletType).to.equal(WALLET_TYPES.HDWALLET);
     expect(self1.mnemonic).to.equal(knifeFixture.mnemonic);
     expect(self1.HDPrivateKey.toString()).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
     expect(new Dashcore.HDPrivateKey(self1.HDPrivateKey)).to.equal(self1.HDPrivateKey);
-    expect(self1.keyChain.type).to.equal('HDRootKey');
-    expect(self1.keyChain.HDRootKey.toString()).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
+    expect(self1.keyChain.type).to.equal('HDPrivateKey');
+    expect(self1.keyChain.HDPrivateKey.toString()).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
     expect(self1.keyChain.keys).to.deep.equal({});
 
 
     const self2 = { network: Dashcore.Networks.testnet };
     fromMnemonic.call(self2, knifeFixture.mnemonic);
-    expect(self2.type).to.equal(WALLET_TYPES.HDWALLET);
+    expect(self2.walletType).to.equal(WALLET_TYPES.HDWALLET);
     expect(self2.mnemonic).to.equal(knifeFixture.mnemonic);
     expect(self2.HDPrivateKey.toString()).to.equal(knifeFixture.HDRootPrivateKeyTestnet);
     expect(new Dashcore.HDPrivateKey(self1.HDPrivateKey)).to.equal(self1.HDPrivateKey);
-    expect(self2.keyChain.type).to.equal('HDRootKey');
-    expect(self2.keyChain.HDRootKey.toString()).to.equal(knifeFixture.HDRootPrivateKeyTestnet);
+    expect(self2.keyChain.type).to.equal('HDPrivateKey');
+    expect(self2.keyChain.HDPrivateKey.toString()).to.equal(knifeFixture.HDRootPrivateKeyTestnet);
     expect(self2.keyChain.keys).to.deep.equal({});
   });
   it('should reject invalid mnemonic', () => {

--- a/test/Wallet/fromPrivateKey.js
+++ b/test/Wallet/fromPrivateKey.js
@@ -12,7 +12,7 @@ describe('Wallet - fromPrivateKey', () => {
   it('should set wallet from private Key', () => {
     const self1 = {};
     fromPrivateKey.call(self1, cR4t6eFixture.privateKey);
-    expect(self1.type).to.equal(WALLET_TYPES.SINGLE_ADDRESS);
+    expect(self1.walletType).to.equal(WALLET_TYPES.SINGLE_ADDRESS);
     expect(self1.mnemonic).to.equal(null);
     expect(self1.privateKey).to.equal(cR4t6eFixture.privateKey);
     expect(self1.keyChain.type).to.equal('privateKey');
@@ -21,7 +21,7 @@ describe('Wallet - fromPrivateKey', () => {
 
     const self2 = {};
     fromPrivateKey.call(self2, cR4t6eFixture.privateKey);
-    expect(self2.type).to.equal(WALLET_TYPES.SINGLE_ADDRESS);
+    expect(self2.walletType).to.equal(WALLET_TYPES.SINGLE_ADDRESS);
     expect(self2.mnemonic).to.equal(null);
     expect(self2.privateKey).to.equal(cR4t6eFixture.privateKey);
     expect(self2.keyChain.type).to.equal('privateKey');

--- a/test/Wallet/fromSeed.js
+++ b/test/Wallet/fromSeed.js
@@ -12,20 +12,20 @@ describe('Wallet - fromSeed', () => {
   it('should set wallet from a HDPrivateKey', () => {
     const self1 = {};
     fromSeed.call(self1, knifeFixture.HDRootPrivateKeyMainnet);
-    expect(self1.type).to.equal(WALLET_TYPES.HDWALLET);
+    expect(self1.walletType).to.equal(WALLET_TYPES.HDWALLET);
     expect(self1.mnemonic).to.equal(null);
     expect(self1.HDPrivateKey).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
-    expect(self1.keyChain.type).to.equal('HDRootKey');
-    expect(self1.keyChain.HDRootKey).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
+    expect(self1.keyChain.type).to.equal('HDPrivateKey');
+    expect(self1.keyChain.HDPrivateKey).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
     expect(self1.keyChain.keys).to.deep.equal({});
 
     const self2 = {};
     fromSeed.call(self2, knifeFixture.HDRootPrivateKeyMainnet);
-    expect(self2.type).to.equal(WALLET_TYPES.HDWALLET);
+    expect(self2.walletType).to.equal(WALLET_TYPES.HDWALLET);
     expect(self2.mnemonic).to.equal(null);
     expect(self2.HDPrivateKey).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
-    expect(self2.keyChain.type).to.equal('HDRootKey');
-    expect(self2.keyChain.HDRootKey).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
+    expect(self2.keyChain.type).to.equal('HDPrivateKey');
+    expect(self2.keyChain.HDPrivateKey).to.equal(knifeFixture.HDRootPrivateKeyMainnet);
     expect(self2.keyChain.keys).to.deep.equal({});
   });
   it('should reject invalid mnemonic', () => {

--- a/test/Wallet/generateNewWalletId.js
+++ b/test/Wallet/generateNewWalletId.js
@@ -1,14 +1,15 @@
 const { expect } = require('chai');
 const generateNewWalletId = require('../../src/Wallet/generateNewWalletId');
 const knifeMnemonic = require('../fixtures/knifeeasily');
+const gatherSail = require('../fixtures/gathersail');
 const cR4t6ePrivateKey = require('../fixtures/cR4t6e_pk');
 const { WALLET_TYPES } = require('../../src/CONSTANTS');
 
 describe('Wallet - generateNewWalletId', () => {
   it('should indicate on missing data', () => {
     const mockOpts1 = { };
-    const mockOpts2 = { type: WALLET_TYPES.HDWALLET };
-    const mockOpts3 = { type: WALLET_TYPES.SINGLE_ADDRESS };
+    const mockOpts2 = { walletType: WALLET_TYPES.HDWALLET };
+    const mockOpts3 = { walletType: WALLET_TYPES.SINGLE_ADDRESS };
 
     const exceptedException1 = 'Cannot generate a walletId : No HDPrivateKey found';
     const exceptedException3 = 'Cannot generate a walletId : No privateKey found';
@@ -28,9 +29,19 @@ describe('Wallet - generateNewWalletId', () => {
     expect(walletId2).to.length(10);
     expect(walletId2).to.equal(knifeMnemonic.HDPrivateKeyTestnetWalletId);
   });
+  it('should generate a wallet id from HDPubKey', () => {
+    const mockOptsTestnet = {
+      walletType: WALLET_TYPES.HDEXTPUBLIC,
+      HDExtPublicKey: gatherSail.testnet.external.hdpubkey,
+    };
+
+    const walletId1 = generateNewWalletId.call(mockOptsTestnet);
+    expect(walletId1).to.length(10);
+    expect(walletId1).to.equal(gatherSail.testnet.external.walletId);
+  });
   it('should generate a wallet id from single pk', () => {
     const mockOpts = {
-      type: WALLET_TYPES.SINGLE_ADDRESS,
+      walletType: WALLET_TYPES.SINGLE_ADDRESS,
       privateKey: cR4t6ePrivateKey.privateKey,
     };
 

--- a/test/fixtures/gathersail.json
+++ b/test/fixtures/gathersail.json
@@ -1,0 +1,35 @@
+{
+  "mnemonic": "gather sail face invite together focus waste barely excuse slide harbor hint",
+  "testnet": {
+    "coinTypeRoothardened": {
+      "path": "m/44'/1'",
+      "walletId": "a5f693bd42",
+      "hdprivkey": "tprv8dofJF3bpqxuajWyTwnM7PyxCP28ubYAcZ9FmAUsK8mGWGtDsnVGqotKPoPYnqCrqHd5B5PkE6sX2ZX7HXrQLpKGw9EKsfN97LKQ1LMHXK2",
+      "hdpubkey": "tpubDAVhSf5qyDeaUCYmMbSwWoe4mQY54vj5Brk33gXAjQZfLm8zWBJs2JWBZy7ZZaDi2wDQDaBbtC9QAnDrHJSGBUCE9pBhdEZSbD7KqsNAewG"
+    },
+    "accountRootUnhardened": {
+      "walletId": "c8bfa6aece",
+      "path": "m/44'/1'/0",
+      "hdprivkey": "tprv8fPaucpz8koz1x6d1EjuBXaDJqyUknWb2PwPFWXzoL3LUCDbWtw451fCxMBvpYcawck4ER6GJPRyhMapoYD3p5p6gY71uLsYiTJ4Lq7NBSf",
+      "hdpubkey": "tpubDC5d42sEH8VeuR8QttQVawEKssVQv7hVbhYAY2aJDbqjJgUN9HkeFWH58VX5xc5QUW2JDm4ActaFS6NVZUZu6pfijnvPVmUwF84ryPkBSi5"
+    },
+    "accountRootHardened": {
+      "walletId": "84191f1b0d",
+      "path": "m/44'/1'/0'",
+      "hdprivkey": "tprv8fPaucq8URLxAntBgc3dJQ7A9gSZmGCEkfDjiUKqrfxb5hvLhMH2xE9FPxhBmpEdSYbZ7WgV1mVP6Q6CzFbiz3qfRs7pR3QT2ALCWGeVoWn",
+      "hdpubkey": "tpubDC5d42sNco2d4FuyaFiDhomGihxVvbP9KxpWzzN9GwkyvCB7Kk6d8im7a86EzYetBJ3fVywD3TtkD676HEtHEYNZhjRfbEuDPeUQwgxddFZ"
+    },
+    "external": {
+      "walletId": "58a78501c1",
+      "path": "m/44'/1'/0'/0",
+      "hdprivkey": "tprv8hV43GTuAYskd2ZTtJGgVtNp9e4ozrj3qD2ksTVHpvETmZjp4KpRFG65J7wK6WhB3z8ixcGgFowtdrXtAorza6LT4aRMUK3NdPHW5bqFUVt",
+      "hdpubkey": "tpubDEB6BgW9JvZRWVbFmwwGuJ2vifakABuxQWdY9yXbFC2rc3zagie1RkhwUEnahb1dzaapchEVeKqKcx99TzkjNvjXcmoQkLJwsYnA1J5bGNj"
+    },
+    "internal": {
+      "walletId": "e1ae985d2d",
+      "path": "m/44'/1'/0'/1",
+      "hdprivkey": "tprv8hV43GTuAYskeXZaJuuZw5kJS8whKashCoDAyr7wNJfC5LM73mfgUsJno7Uy7Db148R9bCgKGPPqWMyU8HhzVi73uwR1RsYF4ietJXpVAvW",
+      "hdpubkey": "tpubDEB6BgW9JvZRXzbNCZaALVQR1ATdUv4bn6oxGNAEnaTaupbsgAVGfMveyF8jkr6MzEWaUFDwUgKy41LaQbPofVpzCxpuwGMze4dvg2KU5f6"
+    }
+  }
+}


### PR DESCRIPTION
### Issue being fixed or implemented
- Ability to use Wallet-lib with an Extended Public Key.

### What was done
- Added HDPublicKey support (considers them HDExtendedPublicKey from external path (m/44'/1'/accIndex/0), and therefore will only deriveChild on asked index.
- Renamed `account.type` in `account.walletType`
- Renamed : `keyChain.HDRootKey` in `keyChain.HDPrivateKey`
- Added `keyChain.HDPublicKey` support.

### Notes
N/A