### PR TITLE
feat: Allow BIP44Worker and SyncWorker to work together

### DIFF
--- a/src/Account/Account.js
+++ b/src/Account/Account.js
@@ -46,6 +46,7 @@ const getUTXOS = require('./getUTXOS');
 const injectPlugin = require('./injectPlugin');
 const sign = require('./sign');
 const updateNetwork = require('./updateNetwork');
+const hasPlugins = require('./hasPlugins');
 
 class Account {
   constructor(wallet, opts = defaultOptions) {
@@ -74,6 +75,7 @@ class Account {
       injectPlugin,
       sign,
       updateNetwork,
+      hasPlugins,
     });
     if (!wallet || wallet.constructor.name !== Wallet.name) throw new Error('Expected wallet to be passed as param');
     if (!_.has(wallet, 'walletId')) throw new Error('Missing walletID to create an account');

--- a/src/Account/Account.js
+++ b/src/Account/Account.js
@@ -37,6 +37,7 @@ const getBIP44Path = require('./getBIP44Path');
 const getDAP = require('./getDAP');
 const getNetwork = require('./getNetwork');
 const getPlugin = require('./getPlugin');
+const getWorker = require('./getWorker');
 const getPrivateKeys = require('./getPrivateKeys');
 const getTransaction = require('./getTransaction');
 const getTransactionHistory = require('./getTransactionHistory');
@@ -66,6 +67,7 @@ class Account {
       getBIP44Path,
       getDAP,
       getPlugin,
+      getWorker,
       getPrivateKeys,
       getTransaction,
       getTransactionHistory,

--- a/src/Account/_initializeAccount.js
+++ b/src/Account/_initializeAccount.js
@@ -36,6 +36,24 @@ async function _initializeAccount(account, userUnsafePlugins) {
       account.injectPlugin(UnsafePlugin, account.allowSensitiveOperations);
     });
 
+
+    const sendReady = () => {
+      if (!self.isReady) {
+        self.events.emit(EVENTS.READY);
+        self.isReady = true;
+      }
+    };
+    const recursivelyGenerateAddresses = async () => {
+      const bip44worker = account.getWorker('BIP44Worker');
+      const syncWorker = account.getWorker('syncWorker');
+      const exec = async () => {
+        await syncWorker.execute();
+        return bip44worker.ensureEnoughAddress();
+      };
+      if (await exec() !== 0) return recursivelyGenerateAddresses();
+      return true;
+    };
+
     // eslint-disable-next-line no-param-reassign,consistent-return
     account.readinessInterval = setInterval(() => {
       const watchedWorkers = Object.keys(account.plugins.watchers);
@@ -46,14 +64,28 @@ async function _initializeAccount(account, userUnsafePlugins) {
         }
       });
       if (readyWorkers === watchedWorkers.length) {
-        self.events.emit(EVENTS.READY);
-        self.isReady = true;
+        // If both of the plugins are present
+        // We need to tweak it a little bit to have BIP44 ensuring address
+        // while SyncWorker fetch'em on network
         clearInterval(self.readinessInterval);
-        return res(true);
+        if (account.hasPlugins([BIP44Worker, SyncWorker])) {
+          recursivelyGenerateAddresses()
+            .catch(() => {
+              console.error('Unable to generate addresses');
+            })
+            .finally(() => {
+              sendReady();
+              return res(true);
+            });
+        } else {
+          sendReady();
+          return res(true);
+        }
       }
-    }, 600);
+    });
 
     self.events.emit(EVENTS.STARTED);
   });
 }
+
 module.exports = _initializeAccount;

--- a/src/Account/_initializeAccount.js
+++ b/src/Account/_initializeAccount.js
@@ -70,10 +70,12 @@ async function _initializeAccount(account, userUnsafePlugins) {
         clearInterval(self.readinessInterval);
         if (account.hasPlugins([BIP44Worker, SyncWorker])) {
           recursivelyGenerateAddresses()
+            .then(() => {
+              sendReady();
+              return res(true);
+            })
             .catch(() => {
               console.error('Unable to generate addresses');
-            })
-            .finally(() => {
               sendReady();
               return res(true);
             });

--- a/src/Account/_initializeAccount.js
+++ b/src/Account/_initializeAccount.js
@@ -82,7 +82,7 @@ async function _initializeAccount(account, userUnsafePlugins) {
           return res(true);
         }
       }
-    });
+    }, 600);
 
     self.events.emit(EVENTS.STARTED);
   });

--- a/src/Account/getWorker.js
+++ b/src/Account/getWorker.js
@@ -1,0 +1,18 @@
+const {
+  UnknownDAP,
+} = require('../errors/index');
+/**
+ * Get a worker by it's name
+ * @param dapName
+ * @return {*}
+ */
+function getDAP(dapName) {
+  const loweredDapName = dapName.toLowerCase();
+  const dapsList = Object.keys(this.plugins.workers).map(key => key.toLowerCase());
+  if (dapsList.includes(loweredDapName)) {
+    return this.plugins.workers[loweredDapName];
+  }
+  throw new UnknownDAP(loweredDapName);
+}
+
+module.exports = getDAP;

--- a/src/Account/hasPlugins.js
+++ b/src/Account/hasPlugins.js
@@ -1,0 +1,30 @@
+const _ = require('lodash');
+/**
+ * To any object passed (Transaction, ST,..), will try to sign the message given passed keys.
+ * @param plugins {Array} - Array of constructor
+ */
+module.exports = function hasPlugins(searchedPlugins) {
+  const search = {
+    found: false,
+    results: [],
+  };
+  const { plugins } = this;
+  _.each(searchedPlugins, (searchedPlugin) => {
+    const result = {};
+    _.each(['workers', 'daps', 'standard'], (pluginTypeName) => {
+      const pluginType = plugins[pluginTypeName];
+      _.each(pluginType, (plugin) => {
+        if (searchedPlugin.name === plugin.constructor.name) {
+          result.name = plugin.name;
+        }
+      });
+    });
+    if (result.name) {
+      search.results.push(result);
+    }
+  });
+  if (searchedPlugins.length === search.results.length) {
+    search.found = true;
+  }
+  return search;
+};

--- a/src/plugins/Workers/BIP44Worker.js
+++ b/src/plugins/Workers/BIP44Worker.js
@@ -116,7 +116,7 @@ class BIP44Worker extends Worker {
       const startingIndex = index;
       const lastIndex = addressToGenerate + startingIndex;
       if (lastIndex > startingIndex) {
-        for (let i = startingIndex; i <= lastIndex; i++) {
+        for (let i = startingIndex; i <= lastIndex; i += 1) {
           this.getAddress(i, 'external');
           generated += 1;
           if (walletType === WALLET_TYPES.HDWALLET) {

--- a/src/plugins/Workers/BIP44Worker.js
+++ b/src/plugins/Workers/BIP44Worker.js
@@ -52,6 +52,8 @@ const getMissingIndexes = (paths, fromOrigin = true) => {
   missingIndex = missingIndex.sort((a, b) => a - b);
   return missingIndex;
 };
+
+// TODO : REfacto
 class BIP44Worker extends Worker {
   constructor() {
     super({
@@ -65,6 +67,7 @@ class BIP44Worker extends Worker {
   }
 
   ensureEnoughAddress() {
+    let generated = 0;
     let unusedAddress = 0;
     const store = this.storage.getStore();
     const addresses = store.wallets[this.walletId].addresses.external;
@@ -86,7 +89,7 @@ class BIP44Worker extends Worker {
     addressesPaths = Object
       .keys(store.wallets[this.walletId].addresses.external)
       .filter(el => parseInt(el.split('/')[3], 10) === accountIndex)
-      // sort by index
+    // sort by index
       .sort(sortByIndex);
 
     // Scan already generated addresse and count how many are unused
@@ -105,18 +108,27 @@ class BIP44Worker extends Worker {
 
     const addressToGenerate = BIP44_ADDRESS_GAP - unusedAddress;
     if (addressToGenerate > 0) {
-      const lastElem = addresses[addressesPaths[addressesPaths.length - 1]];
+      const lastElemPath = addressesPaths[addressesPaths.length - 1];
+      const lastElem = addresses[lastElemPath];
+
       const index = (is.def(lastElem)) ? lastElem.index + 1 : 0;
-      for (let i = index; i <= addressToGenerate; i += 1) {
-        this.getAddress(i, 'external');
-        if (walletType === WALLET_TYPES.HDWALLET) {
-          this.getAddress(i, 'internal');
+
+      const startingIndex = index;
+      const lastIndex = addressToGenerate + startingIndex;
+      if (lastIndex > startingIndex) {
+        for (let i = startingIndex; i <= lastIndex; i++) {
+          this.getAddress(i, 'external');
+          generated += 1;
+          if (walletType === WALLET_TYPES.HDWALLET) {
+            this.getAddress(i, 'internal');
+          }
         }
       }
     }
 
-    return true;
+    return generated;
   }
+
 
   execute() {
     // Following BIP44 Account Discovery section, we will scan the external chain of this account.
@@ -125,4 +137,5 @@ class BIP44Worker extends Worker {
     this.ensureEnoughAddress();
   }
 }
+
 module.exports = BIP44Worker;


### PR DESCRIPTION
### Issue being fixed or implemented
While setting these plugins together will do what we expect from them (aka : Keeping 20 unused address in our pool), on first execution, however, only the 20 first will be fetched (as BIP44 do not know yet if they are used or not). 
We therefore need to have a recursive interaction between them to ensure on start enought addresses.

### What was done
- Feat : Added methods in Account `hasPlugins`, `getWorker`
- Impr : initializeAccount will recursively check for both enough addresses + fetch data from network.

### Notes
Fixes DPW-710, makes initializeAccount longer depending on walletHistory.
Might require refactoring later and may be a timeout force exit (to avoid getting stuck there in case of bad connectivity ?)