### PR TITLE
feat: Added DAP Verification/Registration on WLib startup

### DIFF
--- a/src/Account/injectPlugin.js
+++ b/src/Account/injectPlugin.js
@@ -3,7 +3,7 @@ const {
   InjectionErrorCannotInject,
   InjectionErrorCannotInjectUnknownDependency,
 } = require('../errors/index');
-const {is} = require('../utils');
+const { is } = require('../utils');
 /**
  * Will try to inject a given plugin. If needed, it will construct the object first (new).
  * @param UnsafePlugin - Either a child object, or it's parent class to inject
@@ -12,9 +12,9 @@ const {is} = require('../utils');
  * @return {Promise<*>}
  */
 module.exports = async function injectPlugin(
-    UnsafePlugin,
-    allowSensitiveOperations = false,
-    awaitOnInjection = true,
+  UnsafePlugin,
+  allowSensitiveOperations = false,
+  awaitOnInjection = true,
 ) {
   // TODO : Only called internally, it might be worth to remove public access to it.
   // For now, it helps us on debugging
@@ -28,7 +28,7 @@ module.exports = async function injectPlugin(
     if (_.isEmpty(plugin)) rej(new InjectionErrorCannotInject(pluginName, 'Empty plugin'));
 
     // All plugins will require the event object
-    const {pluginType} = plugin;
+    const { pluginType } = plugin;
 
     plugin.inject('events', self.events);
 

--- a/src/Account/injectPlugin.js
+++ b/src/Account/injectPlugin.js
@@ -91,7 +91,7 @@ module.exports = async function injectPlugin(
       else plugin.onInjected();
     }
 
-    if (pluginType === 'DAP') {
+    if (pluginType === 'DAP' && plugin.verifyOnInjected) {
       await plugin.verifyDAP(this.transport.transport);
     }
 

--- a/src/Account/injectPlugin.js
+++ b/src/Account/injectPlugin.js
@@ -3,7 +3,7 @@ const {
   InjectionErrorCannotInject,
   InjectionErrorCannotInjectUnknownDependency,
 } = require('../errors/index');
-const { is } = require('../utils');
+const {is} = require('../utils');
 /**
  * Will try to inject a given plugin. If needed, it will construct the object first (new).
  * @param UnsafePlugin - Either a child object, or it's parent class to inject
@@ -12,9 +12,9 @@ const { is } = require('../utils');
  * @return {Promise<*>}
  */
 module.exports = async function injectPlugin(
-  UnsafePlugin,
-  allowSensitiveOperations = false,
-  awaitOnInjection = true,
+    UnsafePlugin,
+    allowSensitiveOperations = false,
+    awaitOnInjection = true,
 ) {
   // TODO : Only called internally, it might be worth to remove public access to it.
   // For now, it helps us on debugging
@@ -28,7 +28,7 @@ module.exports = async function injectPlugin(
     if (_.isEmpty(plugin)) rej(new InjectionErrorCannotInject(pluginName, 'Empty plugin'));
 
     // All plugins will require the event object
-    const { pluginType } = plugin;
+    const {pluginType} = plugin;
 
     plugin.inject('events', self.events);
 
@@ -51,6 +51,7 @@ module.exports = async function injectPlugin(
         } else rej(new InjectionErrorCannotInjectUnknownDependency(pluginName, dependencyName));
       }
     });
+
     switch (pluginType) {
       case 'Worker':
         self.plugins.workers[pluginName] = plugin;
@@ -85,12 +86,14 @@ module.exports = async function injectPlugin(
         break;
     }
 
-
     if (is.fn(plugin.onInjected)) {
       if (awaitOnInjection) await plugin.onInjected();
       else plugin.onInjected();
     }
 
+    if (pluginType === 'DAP') {
+      await plugin.verifyDAP(this.transport.transport);
+    }
 
     return res(plugin);
   });

--- a/src/plugins/DAP.js
+++ b/src/plugins/DAP.js
@@ -1,9 +1,10 @@
 const DashPlatformProtocol = require('@dashevo/dpp');
+const { Transaction } = require('@dashevo/dashcore-lib');
 const StandardPlugin = require('./StandardPlugin');
 
 class DAP extends StandardPlugin {
   constructor(opts) {
-    super(Object.assign({type: 'DAP'}, opts));
+    super(Object.assign({ type: 'DAP' }, opts));
     this.schema = (opts.schema) ? opts.schema : null;
     this.isValid = false;
   }
@@ -11,13 +12,13 @@ class DAP extends StandardPlugin {
   initDPP() {
     const dpp = new DashPlatformProtocol();
     const dapName = this.name.toLowerCase();
-    const {schema} = this;
+    const { schema } = this;
     if (!schema) {
       throw new Error('Missing DAP Schema. Cannot init DPP');
     }
     const contract = dpp.contract.create(dapName, schema);
     if (!dpp.contract.validate(contract)
-        .isValid()) {
+      .isValid()) {
       throw new Error('Invalid DAP Contract');
     }
     dpp.setContract(contract);
@@ -50,8 +51,59 @@ class DAP extends StandardPlugin {
       }
     }
   }
-  register(){
-    console.log('Register a DAP');
+
+  async register(buser, privateKey = null) {
+    console.log(`Registering DAP : ${this.name}`);
+    const creditFeeSet = 1000;
+    if (!this.dpp) {
+      this.initDPP();
+    }
+    const { dpp } = this;
+    if (!buser) {
+      throw new Error('A BUser Object is required to register (see @dashevo/dashpay-dpa)');
+    }
+    if (!buser.regtxid) {
+      console.log(`'Registering DAP : ${this.name} - Missing regtxid, trying synchronize...`);
+      try {
+        await buser.synchronize();
+      } catch (e) {
+        console.error(e);
+        throw new Error('Invalid BUser or inable to synchronize (regtxid missing.)');
+      }
+    }
+    if (!buser.isOwned && !privateKey) {
+      throw new Error('Either pass a owned buser or a private key to register the dpa');
+    }
+    const { regtxid, subtx } = buser;
+    const signingKey = buser.privateKey || privateKey;
+    if (!signingKey) throw new Error('A signingKey is required to sign the transaction');
+    const dppContract = dpp.getContract();
+
+    const stPacket = dpp.packet.create(dppContract);
+
+    const hashPrevSubTx = (subtx.length === 0)
+      ? regtxid
+      : Array.from(subtx)
+        .pop();
+
+    const transaction = new Transaction()
+      .setType(Transaction.TYPES.TRANSACTION_SUBTX_TRANSITION);
+
+    transaction.extraPayload
+      .setRegTxId(regtxid)
+      .setHashPrevSubTx(hashPrevSubTx)
+      .setHashSTPacket(stPacket.hash())
+      .setCreditFee(creditFeeSet)
+      .sign(signingKey);
+
+    const txid = await this.transport.transport.sendRawTransition(
+      transaction.serialize(),
+      stPacket.serialize()
+        .toString('hex'),
+    );
+
+    console.log(`DAP ${dppContract.name} Registered (txid ${txid}.)`);
+    return txid;
   }
 }
 

--- a/src/plugins/DAP.js
+++ b/src/plugins/DAP.js
@@ -2,11 +2,18 @@ const DashPlatformProtocol = require('@dashevo/dpp');
 const { Transaction } = require('@dashevo/dashcore-lib');
 const StandardPlugin = require('./StandardPlugin');
 
+const defaultOpts = {
+  schema: null,
+  verifyOnInjected: true,
+  isValid: false,
+};
+
 class DAP extends StandardPlugin {
   constructor(opts) {
     super(Object.assign({ type: 'DAP' }, opts));
-    this.schema = (opts.schema) ? opts.schema : null;
-    this.isValid = false;
+    this.schema = (opts.schema !== undefined) ? opts.schema : defaultOpts.schema;
+    this.verifyOnInjected = (opts.verifyOnInjected !== undefined) ? opts.verifyOnInjected : defaultOpts.verifyOnInjected;
+    this.isValid = (opts.isValid !== undefined) ? opts.isValid : defaultOpts.isValid;
   }
 
   initDPP() {

--- a/src/plugins/DAP.js
+++ b/src/plugins/DAP.js
@@ -1,15 +1,58 @@
+const DashPlatformProtocol = require('@dashevo/dpp');
 const StandardPlugin = require('./StandardPlugin');
 
 class DAP extends StandardPlugin {
   constructor(opts) {
-    super(Object.assign({ type: 'DAP' }, opts));
+    super(Object.assign({type: 'DAP'}, opts));
+    this.schema = (opts.schema) ? opts.schema : null;
     this.isValid = false;
   }
 
-  verifyDAP() {
-    return this.isValid;
-    // TODO: Schema validation ?
-    // TODO : Verify if DAP is reachable via DAPI ?
+  initDPP() {
+    const dpp = new DashPlatformProtocol();
+    const dapName = this.name.toLowerCase();
+    const {schema} = this;
+    if (!schema) {
+      throw new Error('Missing DAP Schema. Cannot init DPP');
+    }
+    const contract = dpp.contract.create(dapName, schema);
+    if (!dpp.contract.validate(contract)
+        .isValid()) {
+      throw new Error('Invalid DAP Contract');
+    }
+    dpp.setContract(contract);
+    this.dpp = dpp;
+  }
+
+  async verifyDAP(transporter) {
+    if (!this.schema) {
+      throw new Error('Missing DAP Schema. Cannot verify');
+    }
+    if (!this.dpp) {
+      this.initDPP();
+    }
+    const contractId = this.dpp.getContract().getId();
+    console.log('Verifying DAP ID', contractId);
+
+    if (!transporter || !transporter.fetchContract) {
+      throw new Error('Require transporter to have a fetchContract method to verify DAP Contract');
+    }
+    try {
+      await transporter.fetchContract(contractId);
+      this.isValid = true;
+      return this.isValid;
+    } catch (e) {
+      const isContractNotFoundError = new RegExp('Contract.*not.*found.*', 'g');
+      if (isContractNotFoundError.test(e.message)) {
+        throw new Error('Contract not present on the network. Did you `register`-ed it ? ');
+      } else {
+        throw e;
+      }
+    }
+  }
+  register(){
+    console.log('Register a DAP');
   }
 }
+
 module.exports = DAP;

--- a/src/plugins/DAP.js
+++ b/src/plugins/DAP.js
@@ -12,7 +12,9 @@ class DAP extends StandardPlugin {
   constructor(opts) {
     super(Object.assign({ type: 'DAP' }, opts));
     this.schema = (opts.schema !== undefined) ? opts.schema : defaultOpts.schema;
-    this.verifyOnInjected = (opts.verifyOnInjected !== undefined) ? opts.verifyOnInjected : defaultOpts.verifyOnInjected;
+    this.verifyOnInjected = opts.verifyOnInjected !== undefined
+      ? opts.verifyOnInjected
+      : defaultOpts.verifyOnInjected;
     this.isValid = (opts.isValid !== undefined) ? opts.isValid : defaultOpts.isValid;
   }
 


### PR DESCRIPTION
### Issue being fixed or implemented
Right now, it would be required to a develop to handle the verification of it's dap against the network by itself. However, using standardized transporter, we know the method `fetchContract` is required and present. 
Therefore we can automate the verification of a DAP directly in the start up process. This only requires to a DAP maker to pass `schema:` as an argument (see screenshot below). 
We also needed a registration method as handler for DAP maker. 

### What was done
- added DAP registration
- added DAP verification directly into DAP.js
- when a plugin is a DAP, will add verification as part of the process. 

### Notes

![image](https://user-images.githubusercontent.com/5849920/59300766-46a66500-8c90-11e9-90d1-9e8e67bfda9a.png)

