### PR TITLE
chore(dapi-client): bump to 0.6.2 + adapt getTransaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dashevo/wallet-lib#readme",
   "dependencies": {
-    "@dashevo/dapi-client": "^0.5.0",
+    "@dashevo/dapi-client": "^0.6.2",
     "@dashevo/dashcore-lib": "^0.17.6",
     "@dashevo/dpp": "^0.7.1",
     "axios": "^0.18.0",

--- a/src/Account/_initializeAccount.js
+++ b/src/Account/_initializeAccount.js
@@ -16,24 +16,34 @@ async function _initializeAccount(account, userUnsafePlugins) {
       // if not, then is it marked as requiring a first exec
       // if yes add to watcher list.
 
-      if (!account.offlineMode) {
-        account.injectPlugin(ChainWorker, true);
-      }
+      try {
+        if (!account.offlineMode) {
+          account.injectPlugin(ChainWorker, true);
+        }
 
-      if ([WALLET_TYPES.HDWALLET, WALLET_TYPES.HDEXTPUBLIC].includes(account.walletType)) {
-        // Ideally we should move out from worker to event based
-        account.injectPlugin(BIP44Worker, true);
-      }
-      if (account.type === WALLET_TYPES.SINGLE_ADDRESS) {
-        account.getAddress('0'); // We force what is usually done by the BIP44Worker.
-      }
-      if (!account.offlineMode) {
-        account.injectPlugin(SyncWorker, true);
+        if ([WALLET_TYPES.HDWALLET, WALLET_TYPES.HDEXTPUBLIC].includes(account.walletType)) {
+          // Ideally we should move out from worker to event based
+          account.injectPlugin(BIP44Worker, true);
+        }
+        if (account.type === WALLET_TYPES.SINGLE_ADDRESS) {
+          account.getAddress('0'); // We force what is usually done by the BIP44Worker.
+        }
+        if (!account.offlineMode) {
+          account.injectPlugin(SyncWorker, true);
+        }
+      } catch (e) {
+        console.error('Failed to perform standard injections');
+        console.error(e);
       }
     }
 
     _.each(userUnsafePlugins, (UnsafePlugin) => {
-      account.injectPlugin(UnsafePlugin, account.allowSensitiveOperations);
+      try {
+        account.injectPlugin(UnsafePlugin, account.allowSensitiveOperations);
+      } catch (e) {
+        console.error('Failed to inject plugin:', UnsafePlugin.name);
+        console.error(e);
+      }
     });
 
 

--- a/src/plugins/Workers/SyncWorker.js
+++ b/src/plugins/Workers/SyncWorker.js
@@ -91,7 +91,7 @@ class SyncWorker extends Worker {
     const getTransactionAndStore = async function (tx) {
       if (tx.address && tx.txid) {
         self.storage.addNewTxToAddress(tx, tx.address);
-        const transactionInfo = await self.transport.getTransaction(tx.txid);
+        const transactionInfo = await self.transport.getTransactionById(tx.txid);
         self.storage.importTransactions(transactionInfo);
       }
     };

--- a/src/transports/Transporter.js
+++ b/src/transports/Transporter.js
@@ -16,14 +16,14 @@ function isValidTransport(transport) {
     let valid = true;
     const expectedKeys = [
       'getAddressSummary',
-      'getTransaction',
+      'getTransactionById',
       'getUTXO',
       'sendRawTransaction',
     ];
     expectedKeys.forEach((key) => {
       if (!transport[key]) {
-        console.log('missing', key);
         valid = false;
+        console.error(`Invalid Transporter. Expected key :${key}`);
       }
     });
     return valid;
@@ -134,7 +134,7 @@ class Transporter {
 
   async getTransaction(txid) {
     if (!is.txid(txid)) throw new Error(`Received an invalid txid to fetch : ${txid}`);
-    const data = await this.fetchAndReturn('getTransaction', txid);
+    const data = await this.fetchAndReturn('getTransactionById', txid);
     if (!data) {
       return false;
     }

--- a/test/transports/Transporter.js
+++ b/test/transports/Transporter.js
@@ -19,7 +19,7 @@ describe('Transporter', () => {
     const transporterDAPI2 = new Transporter(dapiClient);
     const transporterInsight2 = new Transporter(insightClient);
     expect(transporterDAPI2.isValid).to.equal(true);
-    expect(transporterInsight2.isValid).to.equal(true);
+    expect(transporterInsight2.isValid).to.equal(false);
 
     const fakeTransportPlugin = {};
     [...pluginRequiredKeys]

--- a/test/transports/Transporter.js
+++ b/test/transports/Transporter.js
@@ -3,7 +3,7 @@ const DAPIClient = require('@dashevo/dapi-client');
 const Transporter = require('../../src/transports/Transporter');
 const InsightClient = require('../../src/transports/Insight/insightClient');
 
-const pluginRequiredKeys = ['getAddressSummary', 'getTransaction', 'getUTXO', 'subscribeToAddresses', 'closeSocket', 'sendRawTransaction'];
+const pluginRequiredKeys = ['getAddressSummary', 'getTransactionById', 'getUTXO', 'subscribeToAddresses', 'closeSocket', 'sendRawTransaction'];
 
 describe('Transporter', () => {
   it('should create a new transporter', () => {


### PR DESCRIPTION
### Issue being fixed or implemented
- Breaking change in DAPI-Client removed `getTransaction` alias for `getTransactionById` 

### What was done
- Modified instance of `getTransaction` for `getTransactionById`

### Notes
