### PR TITLE
chore(package): refer to branch with hardcoded excluded ip.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -265,12 +265,11 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.6.3.tgz",
-      "integrity": "sha512-yYrPjeYOZWlCqhu11K0lkQNXm03Df98xfGv50aUoXo2JSFUybOh9L1j21NslRmyIxb/n0X31IXOfCg/LF6QfzA==",
+      "version": "git+https://github.com/dashevo/dapi-client.git#f8d764cb8f54a2bc411ebceccb24bad2236da407",
+      "from": "git+https://github.com/dashevo/dapi-client.git#temp/exclusion",
       "requires": {
         "@babel/polyfill": "^7.2.5",
-        "@dashevo/dapi-grpc": "^0.8.4",
+        "@dashevo/dapi-grpc": "^0.9.4",
         "@dashevo/dash-spv": "^1.1.5",
         "@dashevo/dashcore-lib": "^0.17.1",
         "axios": "^0.19.0",
@@ -316,15 +315,16 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.8.4.tgz",
-      "integrity": "sha512-S2ve+3kcecwVMAd0flFJ5fOlvX//knwElCESuMRQppTpZOa8WEh3smtvs/sEKjFK24oFXEYcosEKoud+KOvJLw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.9.4.tgz",
+      "integrity": "sha512-jpOUxBrfFhL4LpF9r6v1QjAgzfMoxfyBvoPQftey3Qukl9jMtez/4NGoGousBLmF9dctLEjpRxNlBVuxEWooTQ==",
       "requires": {
-        "@grpc/proto-loader": "^0.5.0",
-        "google-protobuf": "^3.7.1",
-        "grpc": "^1.19.0",
-        "grpc-web": "^1.0.4",
-        "lodash.snakecase": "^4.1.1"
+        "@grpc/proto-loader": "^0.5.1",
+        "google-protobuf": "^3.8.0",
+        "grpc": "^1.22.0",
+        "grpc-web": "^1.0.5",
+        "lodash.snakecase": "^4.1.1",
+        "protobufjs": "^6.8.8"
       }
     },
     "@dashevo/dark-gravity-wave": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/dashevo/wallet-lib#readme",
   "dependencies": {
-    "@dashevo/dapi-client": "^0.6.2",
+    "@dashevo/dapi-client": "https://github.com/dashevo/dapi-client.git#temp/exclusion",
     "@dashevo/dashcore-lib": "^0.17.6",
     "@dashevo/dpp": "^0.7.1",
     "axios": "^0.18.0",


### PR DESCRIPTION
### Issue being fixed or implemented
One of the DAPI node is buggy. For short-term, we push that to refer to a branch without the issue. 

### What was done
- Refer to branch `temp/exclusion`

### Notes
