### PR TITLE
Refactorate : Usage of network object

### DIFF
--- a/examples/wallet-dapi-fromHDPubKey.js
+++ b/examples/wallet-dapi-fromHDPubKey.js
@@ -18,7 +18,7 @@ const account = wallet.getAccount();
 
 const start = async () => {
   console.log('Balance Conf', await account.getConfirmedBalance(false));
-  console.log('Balance Unconf', await account.getUnconfirmedBalance( false));
+  console.log('Balance Unconf', await account.getUnconfirmedBalance(false));
   console.log('New Addr', await account.getUnusedAddress().address);
   //
   // const tx = account.createTransaction({recipient:'yhvXpqQjfN9S4j5mBKbxeGxiETJrrLETg5', amount:5.74});

--- a/examples/wallet-insight-smartrug.js
+++ b/examples/wallet-insight-smartrug.js
@@ -9,8 +9,8 @@ const wallet = new Wallet({
 
 const account = wallet.getAccount();
 const start = async () => {
-  console.log('Balance Conf', await account.getConfirmedBalance( false));
-  console.log('Balance Unconf', await account.getUnconfirmedBalance( false));
+  console.log('Balance Conf', await account.getConfirmedBalance(false));
+  console.log('Balance Unconf', await account.getUnconfirmedBalance(false));
   console.log('New Addr', await account.getUnusedAddress());
 };
 account.events.on(EVENTS.CONFIRMED_BALANCE_CHANGED, (info) => { console.log('CONFIRMED_BALANCE_CHANGED', info, info.delta); });

--- a/src/Account/Account.js
+++ b/src/Account/Account.js
@@ -98,7 +98,7 @@ class Account {
     const accountIndex = _.has(opts, 'accountIndex') ? opts.accountIndex : wallet.accounts.length;
     this.accountIndex = accountIndex;
     this.strategy = _loadStrategy(_.has(opts, 'strategy') ? opts.strategy : defaultOptions.strategy);
-    this.network = getNetwork(wallet.network.toString());
+    this.network = getNetwork(wallet.network).toString();
 
     this.BIP44PATH = getBIP44Path(this.network, accountIndex);
 

--- a/src/Account/createTransaction.js
+++ b/src/Account/createTransaction.js
@@ -113,7 +113,7 @@ function createTransaction(opts) {
     if (el.address) return el.address;
     return Dashcore.Script
       .fromHex(el.scriptPubKey)
-      .toAddress(this.network)
+      .toAddress(this.getNetwork())
       .toString();
   });
 

--- a/src/Account/getBIP44Path.js
+++ b/src/Account/getBIP44Path.js
@@ -9,7 +9,7 @@ const {
  * @return {string} - BIP44 Path to account
  */
 const getBIP44Path = function (network, accountIndex = 0) {
-  return (network === Dashcore.Networks.livenet)
+  return (network === Dashcore.Networks.livenet.toString())
     ? `${BIP44_LIVENET_ROOT_PATH}/${accountIndex}'`
     : `${BIP44_TESTNET_ROOT_PATH}/${accountIndex}'`;
 };

--- a/src/Account/getNetwork.js
+++ b/src/Account/getNetwork.js
@@ -1,5 +1,5 @@
 const Dashcore = require('@dashevo/dashcore-lib');
 
 module.exports = function (network) {
-  return Dashcore.Networks[network] || Dashcore.Networks.testnet;
+  return Dashcore.Networks[network].toString() || Dashcore.Networks.testnet.toString();
 };

--- a/src/Storage/Storage.js
+++ b/src/Storage/Storage.js
@@ -90,7 +90,7 @@ class Storage {
     this.lastRehydrate = null;
     this.lastSave = null;
     this.lastModified = null;
-    this.network = has(opts, 'network') ? opts.network : defaultOpts.network;
+    this.network = has(opts, 'network') ? opts.network.toString() : defaultOpts.network;
     // // Map an address to it's walletid/path/type schema (used by searchAddress for speedup)
     this.mappedAddress = {};
   }

--- a/src/Storage/createWallet.js
+++ b/src/Storage/createWallet.js
@@ -2,7 +2,7 @@ const Dashcore = require('@dashevo/dashcore-lib');
 const { hasProp } = require('../utils');
 
 const { testnet } = Dashcore.Networks;
-const createWallet = function (walletId = 'squawk7700', network = testnet, mnemonic = null, type = null) {
+const createWallet = function (walletId = 'squawk7700', network = testnet.toString(), mnemonic = null, type = null) {
   if (!hasProp(this.store.wallets, walletId)) {
     this.store.wallets[walletId] = {
       accounts: {},

--- a/src/Storage/updateAddress.js
+++ b/src/Storage/updateAddress.js
@@ -37,7 +37,7 @@ const updateAddress = function (addressObj, walletId) {
   // if(newObject.utxos.length==0 && previousObject.utxos.length>0){
   //
   // }
-  const currentBlockHeight = this.store.chains[walletStore.network.name].blockheight;
+  const currentBlockHeight = this.store.chains[walletStore.network].blockheight;
 
   // We calculate here the balanceSat and unconfirmedBalanceSat of our addressObj
   // We do that to avoid getBalance to be slow, so we have to keep that in mind or then

--- a/src/Wallet/Wallet.js
+++ b/src/Wallet/Wallet.js
@@ -59,14 +59,14 @@ class Wallet {
       exportWallet,
     });
 
-    const network = _.has(opts, 'network') ? opts.network : defaultOptions.network;
+    const network = _.has(opts, 'network') ? opts.network.toString() : defaultOptions.network;
     const passphrase = _.has(opts, 'passphrase') ? opts.passphrase : defaultOptions.passphrase;
     this.passphrase = passphrase;
     this.offlineMode = _.has(opts, 'offlineMode') ? opts.offlineMode : defaultOptions.offlineMode;
     this.allowSensitiveOperations = _.has(opts, 'allowSensitiveOperations') ? opts.allowSensitiveOperations : defaultOptions.allowSensitiveOperations;
     this.injectDefaultPlugins = _.has(opts, 'injectDefaultPlugins') ? opts.injectDefaultPlugins : defaultOptions.injectDefaultPlugins;
 
-    if (!(is.network(network))) throw new Error('Expected a valid network (typeof Network or String)');
+    if (!(is.network(network))) throw new Error('Expected a valid network (typeof String)');
     this.network = Dashcore.Networks[network];
 
     if ('mnemonic' in opts) {

--- a/src/Wallet/Wallet.js
+++ b/src/Wallet/Wallet.js
@@ -67,7 +67,10 @@ class Wallet {
     this.injectDefaultPlugins = _.has(opts, 'injectDefaultPlugins') ? opts.injectDefaultPlugins : defaultOptions.injectDefaultPlugins;
 
     if (!(is.network(network))) throw new Error('Expected a valid network (typeof String)');
-    this.network = Dashcore.Networks[network];
+    if (!Dashcore.Networks[network]) {
+      throw new Error(`Un-handled network: ${network}`);
+    }
+    this.network = Dashcore.Networks[network].toString();
 
     if ('mnemonic' in opts) {
       this.fromMnemonic(opts.mnemonic);

--- a/src/Wallet/updateNetwork.js
+++ b/src/Wallet/updateNetwork.js
@@ -1,5 +1,5 @@
 const Dashcore = require('@dashevo/dashcore-lib');
-const { is } = require('../utils/index');
+const {is} = require('../utils/index');
 
 /**
  * Will update network of a Wallet and child accounts
@@ -8,7 +8,8 @@ const { is } = require('../utils/index');
  */
 module.exports = function updateNetwork(network) {
   if (is.network(network) && network !== this.network) {
-    this.network = Dashcore.Networks[network];
+    // Used to ensure network exist in Dashcore
+    this.network = Dashcore.Networks[network].toString();
     // this.transport.updateNetwork(network);
     if (this.accounts) {
       this.accounts.forEach((acc) => {

--- a/src/Wallet/updateNetwork.js
+++ b/src/Wallet/updateNetwork.js
@@ -1,5 +1,5 @@
 const Dashcore = require('@dashevo/dashcore-lib');
-const {is} = require('../utils/index');
+const { is } = require('../utils/index');
 
 /**
  * Will update network of a Wallet and child accounts

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -25,7 +25,7 @@ const is = {
   JSON(val) { try { JSON.stringify(val); return true; } catch (e) { return false; } },
   stringified(val) { try { JSON.parse(val); return true; } catch (e) { return false; } },
   mnemonic: mnemonic => !is.undefOrNull(mnemonic) && (is.string(mnemonic) || mnemonic.constructor.name === Mnemonic.name),
-  network: network => !is.undefOrNull(network) && (is.string(network) || (network.constructor && network.constructor.name === Networks.livenet.constructor.name)),
+  network: network => !is.undefOrNull(network) && (is.string(network)),
   privateKey: pKey => !is.undefOrNull(pKey) && (pKey.constructor.name === PrivateKey.name || (is.string(pKey) && PrivateKey.isValid(pKey))),
   HDPrivateKey: hdKey => !is.undefOrNull(hdKey) && (hdKey.constructor.name === HDPrivateKey.name || (is.string(hdKey) && HDPrivateKey.isValidSerialized(hdKey))),
   HDPublicKey: hdKey => !is.undefOrNull(hdKey) && (hdKey.constructor.name === HDPublicKey.name || (is.string(hdKey) && HDPublicKey.isValidSerialized(hdKey))),

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 // Todo : Some validators here are really proto type of methods, urgent impr is needed here.
 const {
-  PrivateKey, HDPrivateKey, HDPublicKey, Transaction, Mnemonic, Networks, Address,
+  PrivateKey, HDPrivateKey, HDPublicKey, Transaction, Mnemonic, Address,
 } = require('@dashevo/dashcore-lib');
 
 const is = {

--- a/test/Account/getBalance.js
+++ b/test/Account/getBalance.js
@@ -1,4 +1,4 @@
-const {expect} = require('chai');
+const { expect } = require('chai');
 const mockedStore = require('../fixtures/sirentonight-fullstore-snapshot-1562711703');
 const getTotalBalance = require('../../src/Account/getTotalBalance');
 const getConfirmedBalance = require('../../src/Account/getConfirmedBalance');

--- a/test/Storage/Storage.js
+++ b/test/Storage/Storage.js
@@ -53,7 +53,7 @@ describe('Storage - constructor', () => {
       wallets: {
         squawk7700: {
           accounts: {},
-          network: Dashcore.Networks.testnet,
+          network: Dashcore.Networks.testnet.toString(),
           mnemonic: null,
           type: null,
           blockheight: 0,

--- a/test/Storage/createWallet.js
+++ b/test/Storage/createWallet.js
@@ -17,7 +17,7 @@ describe('Storage - createWallet', () => {
       wallets: {
         '123ae': {
           accounts: {},
-          network: Dashcore.Networks.testnet,
+          network: Dashcore.Networks.testnet.toString(),
           mnemonic: null,
           type: null,
           blockheight: 0,
@@ -40,7 +40,7 @@ describe('Storage - createWallet', () => {
       wallets: {
         squawk7700: {
           accounts: {},
-          network: Dashcore.Networks.testnet,
+          network: Dashcore.Networks.testnet.toString(),
           mnemonic: null,
           type: null,
           blockheight: 0,

--- a/test/Wallet/Wallet.js
+++ b/test/Wallet/Wallet.js
@@ -27,13 +27,13 @@ describe('Wallet - class', () => {
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
     expect(wallet1.injectDefaultPlugins).to.be.deep.equal(true);
     expect(wallet1.walletId).to.length(10);
-    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
 
     const wallet2 = new Wallet(mocks);
     expect(wallet2.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
     expect(Dashcore.Mnemonic(wallet2.mnemonic).toString()).to.be.equal(wallet2.mnemonic);
     expect(wallet2.mnemonic).to.be.not.equal(wallet1.mnemonic);
-    expect(wallet2.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet2.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
 
     wallet1.storage.events.on('CONFIGURED', () => {
       wallet1.disconnect();
@@ -49,7 +49,7 @@ describe('Wallet - class', () => {
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
-    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
     expect(wallet1.keyChain.type).to.be.deep.equal('HDPrivateKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
@@ -59,7 +59,7 @@ describe('Wallet - class', () => {
     const opts2 = Object.assign({ mnemonic: knifeMnemonic.mnemonic, network: 'livenet' }, mocks);
     const wallet2 = new Wallet(opts2);
     expect(wallet2.walletType).to.be.equal(WALLET_TYPES.HDWALLET);
-    expect(wallet2.network).to.be.deep.equal(Dashcore.Networks.mainnet);
+    expect(wallet2.network).to.be.deep.equal(Dashcore.Networks.mainnet.toString());
     expect(Dashcore.Mnemonic(wallet2.mnemonic).toString()).to.be.equal(wallet2.mnemonic);
     expect(wallet2.walletId).to.be.equal(knifeMnemonic.walletIdMainnet);
     wallet1.storage.events.on('CONFIGURED', () => {
@@ -76,7 +76,7 @@ describe('Wallet - class', () => {
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
-    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
     expect(wallet1.keyChain.type).to.be.deep.equal('HDPrivateKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
@@ -93,7 +93,7 @@ describe('Wallet - class', () => {
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
-    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
     expect(wallet1.keyChain.type).to.be.deep.equal('HDPublicKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
@@ -110,7 +110,7 @@ describe('Wallet - class', () => {
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
-    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
     expect(wallet1.keyChain.type).to.be.deep.equal('privateKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);
@@ -154,7 +154,7 @@ describe('Wallet - Get/Create Account', () => {
     wallet1.disconnect();
   });
   it('should encrypt wallet with a passphrase', () => {
-    const network = Dashcore.Networks.testnet;
+    const network = Dashcore.Networks.testnet.toString();
     const passphrase = 'Evolution';
     const config = {
       mnemonic: fluidMnemonic.mnemonic,
@@ -170,7 +170,7 @@ describe('Wallet - Get/Create Account', () => {
     });
   });
   it('should be able to create an account at a specific index', (done) => {
-    const network = Dashcore.Networks.testnet;
+    const network = Dashcore.Networks.testnet.toString();
     const passphrase = 'Evolution';
     const config = {
       mnemonic: fluidMnemonic.mnemonic,

--- a/test/Wallet/fromHDPublicKey.js
+++ b/test/Wallet/fromHDPublicKey.js
@@ -43,7 +43,7 @@ describe('Wallet - HDExtPublicKey', () => {
 
     expect(wallet1.plugins).to.be.deep.equal({});
     expect(wallet1.accounts).to.be.deep.equal([]);
-    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet);
+    expect(wallet1.network).to.be.deep.equal(Dashcore.Networks.testnet.toString());
     expect(wallet1.keyChain.type).to.be.deep.equal('HDPublicKey');
     expect(wallet1.passphrase).to.be.deep.equal(null);
     expect(wallet1.allowSensitiveOperations).to.be.deep.equal(false);

--- a/test/Wallet/updateNetwork.js
+++ b/test/Wallet/updateNetwork.js
@@ -17,7 +17,7 @@ describe('Wallet - update network', () => {
       accounts: [{ updateNetwork: () => called += 1 }],
     };
     updateNetwork.call(self1, 'mainnet');
-    expect(self1.network).to.equal(Dashcore.Networks.mainnet);
+    expect(self1.network).to.equal(Dashcore.Networks.mainnet.toString());
     updateNetwork.call(self1, 'testnet');
     expect(self1.network).to.equal(Dashcore.Networks.testnet.toString());
 

--- a/test/Wallet/updateNetwork.js
+++ b/test/Wallet/updateNetwork.js
@@ -19,7 +19,7 @@ describe('Wallet - update network', () => {
     updateNetwork.call(self1, 'mainnet');
     expect(self1.network).to.equal(Dashcore.Networks.mainnet);
     updateNetwork.call(self1, 'testnet');
-    expect(self1.network).to.equal(Dashcore.Networks.testnet);
+    expect(self1.network).to.equal(Dashcore.Networks.testnet.toString());
 
     expect(called).to.equal(2);
     const self2 = {
@@ -27,9 +27,9 @@ describe('Wallet - update network', () => {
       accounts: [{ updateNetwork: () => called += 1 }],
     };
     updateNetwork.call(self2, 'testnet');
-    expect(self2.network).to.equal(Dashcore.Networks.testnet);
+    expect(self2.network).to.equal(Dashcore.Networks.testnet.toString());
     updateNetwork.call(self2, 'mainnet');
-    expect(self2.network).to.equal(Dashcore.Networks.mainnet);
+    expect(self2.network).to.equal(Dashcore.Networks.mainnet.toString());
     expect(called).to.equal(4);
   });
 });

--- a/test/fixtures/walletStore.json
+++ b/test/fixtures/walletStore.json
@@ -9,56 +9,10 @@
               "m/44'/1'/0'": {
                 "label": null,
                 "path": "m/44'/1'/0'",
-                "network": {
-                  "name": "testnet",
-                  "alias": "regtest",
-                  "pubkeyhash": 140,
-                  "privatekey": 239,
-                  "scripthash": 19,
-                  "xpubkey": 70617039,
-                  "xprivkey": 70615956,
-                  "port": 19999,
-                  "networkMagic": {
-                    "type": "Buffer",
-                    "data": [
-                      206,
-                      226,
-                      202,
-                      255
-                    ]
-                  },
-                  "dnsSeeds": [
-                    "testnet-seed.darkcoin.io",
-                    "testnet-seed.dashdot.io",
-                    "test.dnsseed.masternode.io"
-                  ]
-                }
+                "network": "testnet"
               }
             },
-            "network": {
-              "name": "testnet",
-              "alias": "regtest",
-              "pubkeyhash": 140,
-              "privatekey": 239,
-              "scripthash": 19,
-              "xpubkey": 70617039,
-              "xprivkey": 70615956,
-              "port": 19999,
-              "networkMagic": {
-                "type": "Buffer",
-                "data": [
-                  206,
-                  226,
-                  202,
-                  255
-                ]
-              },
-              "dnsSeeds": [
-                "testnet-seed.darkcoin.io",
-                "testnet-seed.dashdot.io",
-                "test.dnsseed.masternode.io"
-              ]
-            },
+            "network":"testnet",
             "mnemonic": "orange endorse vintage grant brother regular miss hobby hand update recall orient",
             "type": "hdwallet",
             "blockheight": 0,

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -198,8 +198,8 @@ describe('Utils', () => {
   });
   it('should is.network work', () => {
     const notANetwork = [];
-    const network = Networks.livenet;
-    const networktestnet = Networks.testnet;
+    const network = Networks.livenet.toString();
+    const networktestnet = Networks.testnet.toString();
     const network2 = 'livenet';
     const network2testnet = 'testnet';
     const notanetwork = notANetwork;


### PR DESCRIPTION
### Issue being fixed or implemented  
Dashcore Lib has a Network prototype, we relied on it as a input of the network parameters in `Wallet`, `Account` and `updateNetwork` methods. 
Starting from there, Wallet-lib will not be an helper on retrieving the full Network instance (`account.getNetwork` was doing that). We will just store the network name. And we add a validation in `Wallet` constructor. 

Fixes #55. 

### What was done  
- Replacing instance of Network object to the string equivalent
- Updated fixtures to removed excessive objects not needed anymore

### Notes  