### PR TITLE
Style : Method composition refact

### DIFF
--- a/src/Account/Account.js
+++ b/src/Account/Account.js
@@ -53,36 +53,6 @@ const hasPlugins = require('./hasPlugins');
 
 class Account {
   constructor(wallet, opts = defaultOptions) {
-    Object.assign(Account.prototype, {
-      broadcastTransaction,
-      connect,
-      createTransaction,
-      disconnect,
-      fetchAddressInfo,
-      fetchStatus,
-      fetchTransactionInfo,
-      forceRefreshAccount,
-      generateAddress,
-      getAddress,
-      getAddresses,
-      getConfirmedBalance,
-      getUnconfirmedBalance,
-      getTotalBalance,
-      getBIP44Path,
-      getDPA,
-      getPlugin,
-      getWorker,
-      getPrivateKeys,
-      getTransaction,
-      getTransactionHistory,
-      getTransactions,
-      getUnusedAddress,
-      getUTXOS,
-      injectPlugin,
-      sign,
-      updateNetwork,
-      hasPlugins,
-    });
     if (!wallet || wallet.constructor.name !== Wallet.name) throw new Error('Expected wallet to be passed as param');
     if (!_.has(wallet, 'walletId')) throw new Error('Missing walletID to create an account');
     this.walletId = wallet.walletId;
@@ -165,11 +135,39 @@ class Account {
         }
       }
     }
-
     this.events.emit(EVENTS.CREATED);
     _addAccountToWallet(this, wallet);
     _initializeAccount(this, wallet.plugins);
   }
 }
+
+Account.prototype.broadcastTransaction = broadcastTransaction;
+Account.prototype.connect = connect;
+Account.prototype.createTransaction = createTransaction;
+Account.prototype.disconnect = disconnect;
+Account.prototype.fetchAddressInfo = fetchAddressInfo;
+Account.prototype.fetchStatus = fetchStatus;
+Account.prototype.fetchTransactionInfo = fetchTransactionInfo;
+Account.prototype.forceRefreshAccount = forceRefreshAccount;
+Account.prototype.generateAddress = generateAddress;
+Account.prototype.getAddress = getAddress;
+Account.prototype.getAddresses = getAddresses;
+Account.prototype.getConfirmedBalance = getConfirmedBalance;
+Account.prototype.getUnconfirmedBalance = getUnconfirmedBalance;
+Account.prototype.getTotalBalance = getTotalBalance;
+Account.prototype.getBIP44Path = getBIP44Path;
+Account.prototype.getDPA = getDPA;
+Account.prototype.getPlugin = getPlugin;
+Account.prototype.getWorker = getWorker;
+Account.prototype.getPrivateKeys = getPrivateKeys;
+Account.prototype.getTransaction = getTransaction;
+Account.prototype.getTransactionHistory = getTransactionHistory;
+Account.prototype.getTransactions = getTransactions;
+Account.prototype.getUnusedAddress = getUnusedAddress;
+Account.prototype.getUTXOS = getUTXOS;
+Account.prototype.injectPlugin = injectPlugin;
+Account.prototype.sign = sign;
+Account.prototype.updateNetwork = updateNetwork;
+Account.prototype.hasPlugins = hasPlugins;
 
 module.exports = Account;

--- a/src/Storage/Storage.js
+++ b/src/Storage/Storage.js
@@ -50,34 +50,6 @@ const _defaultOpts = {
 class Storage {
   constructor(opts = JSON.parse(JSON.stringify(_defaultOpts))) {
     const defaultOpts = JSON.parse(JSON.stringify(_defaultOpts));
-    Object.assign(Storage.prototype, {
-      addNewTxToAddress,
-      addUTXOToAddress,
-      announce,
-      calculateDuffBalance,
-      clearAll,
-      configure,
-      createChain,
-      createWallet,
-      getStore,
-      getTransaction,
-      importAccounts,
-      importAddress,
-      importAddresses,
-      importSingleAddress,
-      importTransaction,
-      importTransactions,
-      rehydrateState,
-      saveState,
-      searchAddress,
-      searchAddressesWithTx,
-      searchTransaction,
-      searchWallet,
-      updateAddress,
-      updateTransaction,
-      startWorker,
-      stopWorker,
-    });
 
     this.events = new EventEmitter();
     this.store = cloneDeep(initialStore);
@@ -99,4 +71,31 @@ class Storage {
     this.events = events;
   }
 }
+Storage.prototype.addNewTxToAddress = addNewTxToAddress;
+Storage.prototype.addUTXOToAddress = addUTXOToAddress;
+Storage.prototype.announce = announce;
+Storage.prototype.calculateDuffBalance = calculateDuffBalance;
+Storage.prototype.clearAll = clearAll;
+Storage.prototype.configure = configure;
+Storage.prototype.createChain = createChain;
+Storage.prototype.createWallet = createWallet;
+Storage.prototype.getStore = getStore;
+Storage.prototype.getTransaction = getTransaction;
+Storage.prototype.importAccounts = importAccounts;
+Storage.prototype.importAddress = importAddress;
+Storage.prototype.importAddresses = importAddresses;
+Storage.prototype.importSingleAddress = importSingleAddress;
+Storage.prototype.importTransaction = importTransaction;
+Storage.prototype.importTransactions = importTransactions;
+Storage.prototype.rehydrateState = rehydrateState;
+Storage.prototype.saveState = saveState;
+Storage.prototype.searchAddress = searchAddress;
+Storage.prototype.searchAddressesWithTx = searchAddressesWithTx;
+Storage.prototype.searchTransaction = searchTransaction;
+Storage.prototype.searchWallet = searchWallet;
+Storage.prototype.updateAddress = updateAddress;
+Storage.prototype.updateTransaction = updateTransaction;
+Storage.prototype.startWorker = startWorker;
+Storage.prototype.stopWorker = stopWorker;
+
 module.exports = Storage;

--- a/src/Wallet/Wallet.js
+++ b/src/Wallet/Wallet.js
@@ -46,16 +46,13 @@ class Wallet {
    * @param opts
    */
   constructor(opts = defaultOptions) {
+    // Immediate prototype method-composition are used in order to give access in constructor.
     Object.assign(Wallet.prototype, {
-      createAccount,
-      disconnect,
-      getAccount,
       fromMnemonic,
       fromSeed,
       fromPrivateKey,
       fromHDExtPublicKey,
       generateNewWalletId,
-      updateNetwork,
       exportWallet,
     });
 
@@ -119,5 +116,12 @@ class Wallet {
     this.savedBackup = false; // TODO: When true, we delete mnemonic from internals
   }
 }
+
+Wallet.prototype.createAccount = createAccount;
+Wallet.prototype.disconnect = disconnect;
+Wallet.prototype.getAccount = getAccount;
+Wallet.prototype.generateNewWalletId = generateNewWalletId;
+Wallet.prototype.updateNetwork = updateNetwork;
+Wallet.prototype.exportWallet = exportWallet;
 
 module.exports = Wallet;


### PR DESCRIPTION
### Issue being fixed or implemented  
`Wallet` constructor initialization requires method that are also available method of it's child. 
Therefore we use a prototype composition as first step. For consistency we did similar to Account, Wallet and Structure. 
Actually, with class expending, with that and dependencies loading (that eslint requires us to have on top of page), the real part of constructor file need scroling below. 
It could also get confusing to use Object.assign. 
Therefore we now just use it where it's immediately needed with a small comment on the why, and put the rest as the norms do (Class.prototoype.stuff = stuff) on bottom of file.

### What was done  
- Complying to norm

### Notes  