### PR TITLE
Doc : Readme picto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Wallet Library
 
-[![NPM Package](https://img.shields.io/npm/v/@dashevo/wallet-lib.svg?style=flat-square)](https://www.npmjs.org/package/@dashevo/wallet--lib)
-[![Build Status](https://img.shields.io/travis/dashevo/wallet-lib.svg?branch=master&style=flat-square)](https://travis-ci.com/dashevo/wallet-lib)
-[![Coverage Status](https://img.shields.io/coveralls/dashevo/wallet-lib.svg?style=flat-square)](https://coveralls.io/github/dashevo/wallet-lib?branch=master)
+[![Package Version](https://img.shields.io/github/package-json/v/dashevo/wallet-lib.svg)](https://www.npmjs.org/package/@dashevo/wallet-lib)
+[![Build Status](https://api.travis-ci.com/dashevo/wallet-lib.svg?branch=master)](https://travis-ci.com/dashevo/wallet-lib)
 
 > A pure and extensible JavaScript Wallet Library for Dash
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wallet Library
 
-[![Package Version](https://img.shields.io/github/package-json/v/dashevo/wallet-lib.svg)](https://www.npmjs.org/package/@dashevo/wallet-lib)
-[![Build Status](https://api.travis-ci.com/dashevo/wallet-lib.svg?branch=master)](https://travis-ci.com/dashevo/wallet-lib)
+[![Package Version](https://img.shields.io/github/package-json/v/dashevo/wallet-lib.svg?&style=flat-square)](https://www.npmjs.org/package/@dashevo/wallet-lib)
+[![Build Status](https://img.shields.io/travis/com/dashevo/wallet-lib.svg?branch=master&style=flat-square)](https://travis-ci.com/dashevo/wallet-lib)
 
 > A pure and extensible JavaScript Wallet Library for Dash
 


### PR DESCRIPTION
### Issue being fixed or implemented  
The service we use for badges have trouble recognizing badges for npm repo that are organization wide (@dashevo/...), therefore we had to rely on something else (github package.json reading)

### What was done  
- Remove coveralls badge (we do not use it)
- Fix Build link
- Use github reading instead of npm

### Notes  