### PR TITLE
impr(SyncWorker): improve tx fetching

### DIFF
--- a/src/plugins/Workers/SyncWorker.js
+++ b/src/plugins/Workers/SyncWorker.js
@@ -157,7 +157,7 @@ class SyncWorker extends Worker {
             if (currBlockheight - tx.blockheight < 20000 && hasReachStandardThreshold) {
               shouldFetch = true;
             }
-          } else if (isUsed && address.transactions.length > 1 && hasReachStandardThreshold){
+          } else if (isUsed && address.transactions.length > 1 && hasReachStandardThreshold) {
             shouldFetch = true;
           }
 

--- a/src/plugins/Workers/SyncWorker.js
+++ b/src/plugins/Workers/SyncWorker.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 const _ = require('lodash');
 const { Worker } = require('../');
 const { ValidTransportLayerRequired, InvalidTransactionObject } = require('../../errors');
@@ -6,8 +7,17 @@ const { UNCONFIRMED_TRANSACTION_STATUS_CODE, SECURE_TRANSACTION_CONFIRMATIONS_NB
 
 // eslint-disable-next-line no-underscore-dangle
 const _defaultOpts = {
-  fetchThreshold: 10 * 60 * 1000,
-  workerIntervalTime: 1 * 10 * 1000,
+  // Thoses are addresses that were used only once, and long time ago.
+  // Low chance of receiving fund. We still check every ten minutes
+  slowFetchThresold: 10 * 60 * 1000,
+  // Those are addresses that we consider standard, InstantSend promise a one minute time,
+  // That is what we offer here (will be changed with streams)
+  fetchThreshold: 60 * 1000,
+  // Those are special cases, such as the current unusedAddress for instance,
+  // Higher chance of receiving tx, we listen in a quite spammy ways.
+  fastFetchThreshold: 15 * 1000,
+  // Loop will go through every 10 sec
+  workerIntervalTime: 10 * 1000,
 };
 
 class SyncWorker extends Worker {
@@ -20,7 +30,7 @@ class SyncWorker extends Worker {
       workerIntervalTime: defaultOpts.workerIntervalTime,
       fetchThreshold: defaultOpts.fetchThreshold,
       dependencies: [
-        'storage', 'transport', 'fetchStatus', 'fetchAddressInfo', 'fetchTransactionInfo', 'walletId', 'getUnusedAddress',
+        'storage', 'transport', 'fetchStatus', 'getTransaction', 'fetchAddressInfo', 'fetchTransactionInfo', 'walletId', 'getUnusedAddress',
       ],
     }, opts);
     super(params);
@@ -101,42 +111,83 @@ class SyncWorker extends Worker {
 
   async execAddressFetching() {
     const self = this;
-    const { addresses } = this.storage.getStore().wallets[this.walletId];
+    const { addresses, network } = this.storage.getStore().wallets[this.walletId];
+    const currBlockheight = this.storage.getStore().chains[network.toString()].blockheight;
+    const currTime = Date.now();
     const { fetchAddressInfo } = this;
 
     const toFetchAddresses = [];
 
-    let prevWasUsed = false;
-    Object.keys(addresses).forEach((walletType) => {
+    let nbPreviousUsed = 0;
+    for (const walletType of Object.keys(addresses)) {
       const walletAddresses = addresses[walletType];
       const walletPaths = Object.keys(walletAddresses);
-
       if (walletPaths.length > 0) {
-        walletPaths.forEach((path) => {
+        for (const path of walletPaths) {
           const address = walletAddresses[path];
+          let shouldFetch = false;
 
-
-          const hasUnconfirmedBalance = address.unconfirmedBalanceSat > 0;
+          const isUsed = address.used;
           // This will make all last address (the one we got from unconfirmedAddress)
           // to basically check each time
-          const isFirstAndUnused = address.used === false && address.index === 0;
-          const hasMostChanceToReceiveTx = prevWasUsed === true && address.used === false;
-          const hasReachRefreshThreshold = address.fetchedLast < (Date.now() - self.fetchThreshold);
-          if (
-            isFirstAndUnused
+          const isFirstAndUnused = isUsed === false && address.index === 0;
+
+          // The five next unused address
+          const hasMostChanceToReceiveTx = nbPreviousUsed < 5 && isUsed === false;
+          const hasUnconfirmedBalance = address.unconfirmedBalanceSat > 0;
+
+          const hasReachFastThreshold = address.fetchedLast < (currTime - self.fastFetchThreshold);
+          const hasReachStandardThreshold = address.fetchedLast < (currTime - self.fetchThreshold);
+          const hasReachSlowThreshold = address.fetchedLast < (currTime - self.slowFetchThresold);
+          // This is for high refresh rate addresses, they still have a threeshold.
+          if ((isFirstAndUnused
               || hasUnconfirmedBalance
-              || hasReachRefreshThreshold
-              || hasMostChanceToReceiveTx
+              || hasMostChanceToReceiveTx) && hasReachFastThreshold
           ) {
+            shouldFetch = true;
+          } else if (!hasReachStandardThreshold) {
+            // Then, if we didn't even reach the standard refresh rate, we don't even care
+            shouldFetch = false;
+            return;
+          } else if (isUsed && address.transactions.length > 10 && hasReachStandardThreshold) {
+            shouldFetch = true;
+          } else if (isUsed && address.transactions.length <= 10) {
+            // It might be a single used and throw address. Let's figure this out
+            let hasYoungTx = false;
+            for (const txId of address.transactions) {
+              // FIXME : It's temporary till we got stream, but in case of, we put this stamp.
+              // eslint-disable-next-line no-await-in-loop
+              const tx = await self.getTransaction(txId);
+              if (!tx || currBlockheight - tx.blockheight < 40000) {
+                hasYoungTx = true;
+                break;
+              }
+            }
+            if ((hasYoungTx && hasReachFastThreshold) || hasReachSlowThreshold) {
+              shouldFetch = true;
+            }
+          } else if (isUsed && address.transactions.length > 10 && hasReachStandardThreshold) {
+            shouldFetch = true;
+          } else if (!isUsed
+              && ((nbPreviousUsed <= 10 && hasReachStandardThreshold) || hasReachSlowThreshold)
+          ) {
+            shouldFetch = true;
+          }
+
+          if (shouldFetch) {
             toFetchAddresses.push(address);
           }
-          prevWasUsed = address.used;
-        });
+          if (!isUsed) {
+            nbPreviousUsed += 1;
+          }
+        }
       }
-    });
+    }
+
     const promises = [];
     toFetchAddresses.forEach((addressObj) => {
-      // We set at false so we don't autofetch utxos. This part will be done in the tx fetching time
+      // We set at false so we don't autofetch utxos.
+      // This part will be done in the tx fetching time
       // const p = fetchAddressInfo(addressObj, false)
       const p = fetchAddressInfo(addressObj)
         .catch((e) => {
@@ -146,8 +197,6 @@ class SyncWorker extends Worker {
       promises.push(p);
     });
 
-    // console.log('fetching addr', toFetchAddresses);
-    // console.log(promises)
     const responses = await Promise.all(promises);
 
     responses.forEach((addrInfo) => {
@@ -163,7 +212,6 @@ class SyncWorker extends Worker {
       }
     });
     this.events.emit(EVENTS.FETCHED_ADDRESS, responses);
-    return true;
   }
 
   async execTransactionsFetching() {

--- a/src/plugins/Workers/SyncWorker.js
+++ b/src/plugins/Workers/SyncWorker.js
@@ -9,7 +9,7 @@ const { UNCONFIRMED_TRANSACTION_STATUS_CODE, SECURE_TRANSACTION_CONFIRMATIONS_NB
 const _defaultOpts = {
   // Thoses are addresses that were used only once, and long time ago.
   // Low chance of receiving fund. We still check every ten minutes
-  slowFetchThresold: 10 * 60 * 1000,
+  slowFetchThresold: 5 * 60 * 1000,
   // Those are addresses that we consider standard, InstantSend promise a one minute time,
   // That is what we offer here (will be changed with streams)
   fetchThreshold: 60 * 1000,


### PR DESCRIPTION
### Issue being fixed or implemented  
From DPW-885 we can learn that some issue have been found in the refresh process of the addresses and their balance. 
One of them was 10 minutes, which make no sense actually, either we are live and we use streams, either we are on demo and then hitting hard DAPI is not that much of an issue. 

### What was done  
- Introduce three threshold (fast, normal, slow). 
- Determine which address need to be fetch in regards of which threshold

### Notes  

Here is the logic : 

- Fast threshold (15 sec): Every address with unconfirmed balance. Five first unused address
-  Slow threshold (5 min): Address with exactly one tx that is >20000 ( 30days) block old (most likely once-used address that will see no refresh ever). 
All unused address except the first 10 (less likely to have any)
- Standard threshold (60 sec): Next 5 to 10 unused address. Address with 1 tx <20000 old. Address that were used more than once
