### PR TITLE
feat: identity keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "scripts": {

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -21,6 +21,8 @@ export declare class Account {
 
     getDPA(name: string): object;
 
+    getIdentityPrivateKey(index: number): PrivateKey;
+
     getNetwork(): Network;
 
     getPlugin(name:string): object;

--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -165,5 +165,6 @@ Account.prototype.updateNetwork = require('./methods/updateNetwork');
 
 Account.prototype.hasPlugins = require('./methods/hasPlugins');
 
+Account.prototype.getIdentityPrivateKey = require('./methods/getIdentityPrivateKey');
 
 module.exports = Account;

--- a/src/types/Account/methods/getIdentityPrivateKey.js
+++ b/src/types/Account/methods/getIdentityPrivateKey.js
@@ -6,7 +6,7 @@
 function getIdentityPrivateKey(index) {
   // TODO: add proper feature-based derivation
   const { address } = this.getAddress(index);
-  const [privateKey] = this.getIdentityPrivateKey([address]);
+  const [privateKey] = this.getPrivateKeys([address]);
   return privateKey.privateKey;
 }
 

--- a/src/types/Account/methods/getIdentityPrivateKey.js
+++ b/src/types/Account/methods/getIdentityPrivateKey.js
@@ -1,0 +1,13 @@
+/**
+ * Return all the private keys matching the PubKey Addr List
+ * @param index<number>
+ * @return <HDPrivateKey>
+ */
+function getPrivateKeys(index) {
+  // TODO: add proper feature-based derivation
+  const { address } = this.getAddress(index);
+  const [privateKey] = this.getPrivateKeys([address]);
+  return privateKey;
+}
+
+module.exports = getPrivateKeys;

--- a/src/types/Account/methods/getIdentityPrivateKey.js
+++ b/src/types/Account/methods/getIdentityPrivateKey.js
@@ -1,13 +1,13 @@
 /**
  * Return all the private keys matching the PubKey Addr List
  * @param index<number>
- * @return <HDPrivateKey>
+ * @return PrivateKey
  */
 function getPrivateKeys(index) {
   // TODO: add proper feature-based derivation
   const { address } = this.getAddress(index);
   const [privateKey] = this.getPrivateKeys([address]);
-  return privateKey;
+  return privateKey.privateKey;
 }
 
 module.exports = getPrivateKeys;

--- a/src/types/Account/methods/getIdentityPrivateKey.js
+++ b/src/types/Account/methods/getIdentityPrivateKey.js
@@ -1,13 +1,13 @@
 /**
- * Return all the private keys matching the PubKey Addr List
- * @param index<number>
- * @return PrivateKey
+ * Returns a private key for managing an identity
+ * @param {number} index - index of an identity
+ * @return {PrivateKey}
  */
-function getPrivateKeys(index) {
+function getIdentityPrivateKey(index) {
   // TODO: add proper feature-based derivation
   const { address } = this.getAddress(index);
-  const [privateKey] = this.getPrivateKeys([address]);
+  const [privateKey] = this.getIdentityPrivateKey([address]);
   return privateKey.privateKey;
 }
 
-module.exports = getPrivateKeys;
+module.exports = getIdentityPrivateKey;

--- a/test/types/Account/getIdentityPrivateKey.js
+++ b/test/types/Account/getIdentityPrivateKey.js
@@ -1,36 +1,30 @@
 const { expect } = require('chai');
 
 const { Account, Wallet } = require('../../../src');
-const mockedStore = require('../../fixtures/sirentonight-fullstore-snapshot-1562711703');
 
-const storageHDW = {
-  store: mockedStore,
-  getStore: () => mockedStore,
-  mappedAddress: {},
-};
-const walletId = Object.keys(mockedStore.wallets)[0];
-const walletMock = {
-  walletId,
-  accountIndex: 0,
-  storage: storageHDW,
-};
-const accountMock = new Account(walletMock, { injectDefaultPlugins: false });
+let mnemonic;
+let expectedIdentityPrivateKey;
+let expectedIdentityPrivateKey1;
+let walletMock;
+let account;
 
 describe('Account - getIdentityPrivateKey', () => {
-  let keychain;
-  const mnemonic = 'during develop before curtain hazard rare job language become verb message travel';
-  const pk = '4226d5e2fe8cbfe6f5beb7adf5a5b08b310f6c4a67fc27826779073be6f5699e';
-  it('should create a keychain', () => {
-    const expectedException1 = 'Expect privateKey, HDPublicKey or HDPrivateKey';
-    expect(() => new KeyChain()).to.throw(expectedException1);
-    expect(() => new KeyChain(mnemonic)).to.throw(expectedException1);
-
-    keychain = new KeyChain({ HDPrivateKey: mnemonicToHDPrivateKey(mnemonic, 'testnet') });
-    expect(keychain.type).to.equal('HDPrivateKey');
-    expect(keychain.network.toString()).to.equal('testnet');
-    expect(keychain.keys).to.deep.equal({});
+  beforeEach(() => {
+    mnemonic = 'during develop before curtain hazard rare job language become verb message travel';
+    expectedIdentityPrivateKey = 'c2c687fb69dbabbc984f020021c40c1e8c96d40c1ce7de335ac55f84ef816098';
+    expectedIdentityPrivateKey1 = '66680bff9a62e2bf1149536d4df62bb2c0c4b0ec99a556f9fe055cf94b94ea7b';
+    walletMock = new Wallet({
+      offlineMode: true,
+      mnemonic,
+    });
+    account = new Account(walletMock);
   });
-  it('should get private key', () => {
-    expect(keychain.getPrivateKey().toString()).to.equal(pk);
+
+  it('Should derive a key for identity for a given index', () => {
+    const actualIdentityPrivateKey = account.getIdentityPrivateKey(0);
+    const actualIdentityPrivateKey1 = account.getIdentityPrivateKey(1);
+
+    expect(actualIdentityPrivateKey.toString()).to.be.equal(expectedIdentityPrivateKey);
+    expect(actualIdentityPrivateKey1.toString()).to.be.equal(expectedIdentityPrivateKey1);
   });
 });

--- a/test/types/Account/getIdentityPrivateKey.js
+++ b/test/types/Account/getIdentityPrivateKey.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+
+const { Account, Wallet } = require('../../../src');
+const mockedStore = require('../../fixtures/sirentonight-fullstore-snapshot-1562711703');
+
+const storageHDW = {
+  store: mockedStore,
+  getStore: () => mockedStore,
+  mappedAddress: {},
+};
+const walletId = Object.keys(mockedStore.wallets)[0];
+const walletMock = {
+  walletId,
+  accountIndex: 0,
+  storage: storageHDW,
+};
+const accountMock = new Account(walletMock, { injectDefaultPlugins: false });
+
+describe('Account - getIdentityPrivateKey', () => {
+  let keychain;
+  const mnemonic = 'during develop before curtain hazard rare job language become verb message travel';
+  const pk = '4226d5e2fe8cbfe6f5beb7adf5a5b08b310f6c4a67fc27826779073be6f5699e';
+  it('should create a keychain', () => {
+    const expectedException1 = 'Expect privateKey, HDPublicKey or HDPrivateKey';
+    expect(() => new KeyChain()).to.throw(expectedException1);
+    expect(() => new KeyChain(mnemonic)).to.throw(expectedException1);
+
+    keychain = new KeyChain({ HDPrivateKey: mnemonicToHDPrivateKey(mnemonic, 'testnet') });
+    expect(keychain.type).to.equal('HDPrivateKey');
+    expect(keychain.network.toString()).to.equal('testnet');
+    expect(keychain.keys).to.deep.equal({});
+  });
+  it('should get private key', () => {
+    expect(keychain.getPrivateKey().toString()).to.equal(pk);
+  });
+});

--- a/test/types/Account/getIdentityPrivateKey.js
+++ b/test/types/Account/getIdentityPrivateKey.js
@@ -20,6 +20,10 @@ describe('Account - getIdentityPrivateKey', () => {
     account = new Account(walletMock);
   });
 
+  afterEach(() => {
+    walletMock.disconnect();
+  });
+
   it('Should derive a key for identity for a given index', () => {
     const actualIdentityPrivateKey = account.getIdentityPrivateKey(0);
     const actualIdentityPrivateKey1 = account.getIdentityPrivateKey(1);


### PR DESCRIPTION
### Issue being fixed or implemented  

Add a method to derive identity-specific keys to the `Account` class

### What was done  

Added a `getIdentityPrivateKey(number): PrivateKey` method to the `Account` class

### How Has This Been Tested?

Integration test added
