### PR TITLE
chore(travis): updated stages process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ before_install:
   - echo -e "machine github.com\n  login ${GH_TOKEN}" >> ~/.netrc
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
-install:
-  - npm ci
-
 jobs:
   include:
     - stage: lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,10 @@ before_install:
 install:
   - npm ci
 
-before_script:
-  - npm run lint
-
 jobs:
   include:
-    - stage: eslint
-      script: npm run lint
     - stage: size
       script: npm run size
-    - stage: test
-      script: npm test
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ install:
 
 jobs:
   include:
+    - stage: lint
+      script: npm run lint
     - stage: size
       script: npm run size
 


### PR DESCRIPTION
### Issue being fixed or implemented  

Right now, on each commit pushed to an open PR, 5 job get running, with two duplicate (node8 - test).
Let's clean up travis.yml with this PR.

### What was done  

Removed stages : `lint` and `test`, also remove before_test lint. 
Also removed `npm ci` as it's part of default too (see notes)

### Notes 

https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#dependency-management
`If package-lock.json or npm-shrinkwrap.json exists and your npm version supports it, Travis CI will use npm ci instead of npm install.`