### PR TITLE
impr: evonet connectivity and related improvement

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -49,6 +49,8 @@ Quick note :
 - If no transport specified, Wallet-lib will connect to DAPI.
 - `wallet.getAccount()` is by default equivalent to `wallet.getAccount(0)`, where 0 correspond of the account index as per [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki).
 
+A sugar-syntax replacement for `account.events.on('ready'), exist in a promise : await account.isReady()`
+
 ## Make a payment to an address
 
 ```js

--- a/docs/usage/account.md
+++ b/docs/usage/account.md
@@ -4,6 +4,8 @@ In Wallet-Lib, an Account represent in an ideal condition (HDWallet) a specific 
 This Account hold all the method that one might want to use, from creating a transaction to getting the transaction history. 
 
 Account will also emit differents [events](#Events) that you can listen for.
+A sugar-syntax replacement for `account.events.on('ready'), exist in a promise : await account.isReady()`
+
 ## Create an Account
 
 ```

--- a/docs/usage/events.md
+++ b/docs/usage/events.md
@@ -5,7 +5,6 @@ const {EVENTS} = require('@dashevo/wallet-lib');
 const {READY} = EVENTS;
 const doSomethingWhenReady = (info) => {...}
 account.events.on(READY, doSomethingWhenReady);
-
 ```
 
 Events types : 

--- a/docs/usage/keychain.md
+++ b/docs/usage/keychain.md
@@ -13,6 +13,26 @@ const hdRootKey = 'tprv8ZgxMBicQKsPeWisxgPVWiXho8ozsAUqc3uvpAhBuoGvSTxqkxPZbTeG4
 const keychain = new KeyChain({HDPrivateKey:hdRootKey});
 ```
 
+
+### getHardenedBIP44Path()
+
+BIP44 define a logical hierarchy for HDWallet (BIP32).  
+This method gives a clusterized root key for all BIP44 derivation need. (m/44'/1' - m/44'/5').
+
+```
+keychain.getHardenedBIP44Path().deriveChild('...')
+```
+
+### getHardenedDIP9FeaturePath()
+
+DIP09 define a logical hierarchy for HDWallet (BIP32).  
+This method gives a clusterized root key for all DIP9 derivation need. (m/9'/1' - m/9'/5').
+
+```
+keychain.getHardenedDIP9FeaturePath().deriveChild('...')
+```
+
+
 ### Get keys for a specific path
 
 ```

--- a/docs/usage/wallet.md
+++ b/docs/usage/wallet.md
@@ -32,7 +32,7 @@ const Wallet = new Wallet(opts);
 
 > **passphrase** : String(def: null) : Set the passphrase to a mnemonic
 
-> **mnemonic** : String|Mnemonic : When set will init the wallet from it.
+> **mnemonic** : String|Mnemonic|null : When set will init the wallet from it. When null generates a new mnemonic.
 
 > **HDPrivateKey** : String|HDPrivateKey : When set will init the wallet from it.
 
@@ -49,6 +49,18 @@ const Wallet = new Wallet(opts);
 > **offlineMode** : Bool(false) : When set at true, the wallet will not try to use any transport layer.
 
 N.B : If mnemonic, seed and privateKey are filled, only mnemonic will be used. If none is entered, the wallet will create a mnemonic.
+
+### Creation without a mnemonic (gets one generated)
+```js
+const wallet = new Wallet();
+```
+or 
+```js
+const wallet = new Wallet({
+  mnemonic: null
+});
+console.log(wallet.exportWallet());
+```
 
 ### Creation from Mnemonic 
 

--- a/examples/wallet-dapi-fromHDPubKey.js
+++ b/examples/wallet-dapi-fromHDPubKey.js
@@ -3,7 +3,7 @@ const logger = require('../src/logger');
 const { Wallet, EVENTS } = require('../src');
 
 const transport = new DAPIClient({
-  seeds: [{ service: '18.237.69.61:3000' }],
+  seeds: [{ service: '18.236.131.253:3000' }],
   timeout: 20000,
   retries: 5,
 });

--- a/examples/wallet-dapi-porto-update.js
+++ b/examples/wallet-dapi-porto-update.js
@@ -3,7 +3,7 @@ const logger = require('../src/logger');
 const { Wallet, EVENTS } = require('../src');
 
 const transport = new DAPIClient({
-  seeds: [{ service: '18.237.69.61:3000' }],
+  seeds: [{ service: '18.236.131.253:3000' }],
   timeout: 20000,
   retries: 5,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -73,9 +73,9 @@
       "dev": true
     },
     "@babel/polyfill": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
-      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
+      "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -137,12 +137,12 @@
       }
     },
     "@dashevo/dapi-client": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.6.7.tgz",
-      "integrity": "sha512-D6EoTEax6EpO9duokDvK6TvU9kk604nkGbU6Sywz2Rt4Zqd3SJf8X6x3ho224PZPrPF3RLrHPAnwniGRnCMxCg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-client/-/dapi-client-0.7.0.tgz",
+      "integrity": "sha512-48G+12JpyGrLm6/LpkJ0zVJSUamPMDEXQT6121LaFOxQ1nD9DHfccomdgUCZG/dQCyI9RI79ULW+Wij3ZRuyPQ==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
-        "@dashevo/dapi-grpc": "^0.9.4",
+        "@dashevo/dapi-grpc": "^0.11.0",
         "@dashevo/dash-spv": "^1.1.5",
         "@dashevo/dashcore-lib": "^0.17.1",
         "axios": "^0.19.0",
@@ -168,15 +168,14 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.9.4.tgz",
-      "integrity": "sha512-jpOUxBrfFhL4LpF9r6v1QjAgzfMoxfyBvoPQftey3Qukl9jMtez/4NGoGousBLmF9dctLEjpRxNlBVuxEWooTQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.11.0.tgz",
+      "integrity": "sha512-z9DymGOp/pUkhS4ILlFHdz1e2jdukMPFltHzaPqZ+egJ0M9Q6GhUARqvNJCZ46TcuHhtkUzxbLQu4UHZ5Zojlg==",
       "requires": {
-        "@grpc/proto-loader": "^0.5.1",
+        "@dashevo/grpc-common": "^0.2.0",
         "google-protobuf": "^3.8.0",
-        "grpc": "^1.22.0",
-        "grpc-web": "^1.0.5",
-        "lodash.snakecase": "^4.1.1",
+        "grpc": "^1.24.0",
+        "grpc-web": "^1.0.6",
         "protobufjs": "^6.8.8"
       }
     },
@@ -247,16 +246,18 @@
       }
     },
     "@dashevo/dpp": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.7.2.tgz",
-      "integrity": "sha512-qjAV3VMN1NXYfVLR12+45Csf0mmeuSMxRGpZZAg08HZSHuESV2R0d3f7ZgX81WdYhvG9OlKEAC5fMQA25JbFhA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.9.1.tgz",
+      "integrity": "sha512-KQZ74s69tn87CIGWzDZRbFyidKTKnP8EG7lqXlGMInhSufF5+aB6GVUD+rM8O6+PrF4QknW7GKMqRTitXWriJw==",
       "requires": {
         "@dashevo/dashcore-lib": "^0.17.8",
         "ajv": "^6.5.4",
         "bs58": "^4.0.1",
         "cbor": "^4.1.1",
         "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2"
+        "lodash.mergewith": "^4.6.2",
+        "lodash.set": "^4.3.2",
+        "multihashes": "^0.4.13"
       },
       "dependencies": {
         "@dashevo/dashcore-lib": {
@@ -287,15 +288,26 @@
         }
       }
     },
+    "@dashevo/grpc-common": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.2.0.tgz",
+      "integrity": "sha512-SzKl/1KCctkvX+ELVo9EybPLw2FLmMvqbLH7rQwPpmslOU7YyohmmGKm0UoZwn3BipZTj8f6tKBN3B9Eq3amYQ==",
+      "requires": {
+        "@grpc/proto-loader": "^0.5.2",
+        "grpc": "^1.24.0",
+        "grpc-health-check": "^1.7.0",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "@dashevo/x11-hash-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@dashevo/x11-hash-js/-/x11-hash-js-1.0.2.tgz",
       "integrity": "sha512-3vvnZweBca4URBXHF+FTrM4sdTpp3IMt73G1zUKQEdYm/kJkIKN94qpFai7YZDl87k64RCH+ckRZk6ruQPz5KQ=="
     },
     "@grpc/proto-loader": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
-      "integrity": "sha512-eBKD/FPxQoY1x6QONW2nBd54QUEyzcFP9FenujmoeDPy1rutVSHki1s/wR68F6O1QfCNDx+ayBH1O2CVNMzyyw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
+      "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -380,6 +392,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+    },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
     },
     "@types/events": {
       "version": "3.0.0",
@@ -609,9 +630,9 @@
       "dev": true
     },
     "abstract-leveldown": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.1.tgz",
-      "integrity": "sha512-zUgomHedGBCThDkUtc1bfilu2jEhRZ7Dk3RePhtMma/akw7UK2Upm2R5Dd8ynRBEt3uscwbWO0VQNx22/7RtWg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
+      "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
       "requires": {
         "level-concat-iterator": "~2.0.0",
         "level-supports": "~1.0.0",
@@ -994,13 +1015,6 @@
       "requires": {
         "follow-redirects": "1.5.10",
         "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
       }
     },
     "balanced-match": {
@@ -1129,17 +1143,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/bloom-filter/-/bloom-filter-0.2.0.tgz",
       "integrity": "sha1-hNY7v5Fy2DA+ZMH/FuudvzOpgaM="
-    },
-    "bls-signatures": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/bls-signatures/-/bls-signatures-0.1.9.tgz",
-      "integrity": "sha512-twdrLsN6WVjy5hjB6KQ0sUjTQxPRvo5PynGk0NAjTB3sbWRUs8KAA1pWa7ArSRTWSN1DoH81W4XRxPX/maB/rw=="
-    },
-    "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
-      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -1671,7 +1674,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -1955,9 +1957,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2039,7 +2041,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -2052,7 +2053,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -4269,9 +4269,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.10.0.tgz",
-      "integrity": "sha512-d0cMO8TJ6xtB/WrVHCv5U81L2ulX+aCD58IljyAN6mHwdHHJ2jbcauX5glvivi3s3hx7EYEo7eUA9WftzamMnw=="
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.2.tgz",
+      "integrity": "sha512-T4fin7lcYLUPj2ChUZ4DvfuuHtg3xi1621qeRZt2J7SvOQusOzq+sDT4vbotWTCjUXJoR36CA016LlhtPy80uQ=="
     },
     "graceful-fs": {
       "version": "4.1.15",
@@ -4285,36 +4285,33 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.0.tgz",
-      "integrity": "sha512-zq1rUh2uzfMqSfQ3bZvlQuX5yKfd/2vob+l9sK5Qma6P33m7UvyMCVW70+Wz0WTzy9W2A94eQD5XIOxKnZhsYQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0",
+        "node-pre-gyp": "^0.14.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "bundled": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -4322,13 +4319,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4340,9 +4335,8 @@
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "chownr": {
-          "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+          "version": "1.1.3",
+          "bundled": true
         },
         "cliui": {
           "version": "3.2.0",
@@ -4356,64 +4350,53 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+          "bundled": true
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": false,
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "bundled": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+          "bundled": true
         },
         "fs-minipass": {
-          "version": "1.2.6",
-          "resolved": false,
-          "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
+          "version": "1.2.7",
+          "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -4427,8 +4410,7 @@
         },
         "glob": {
           "version": "7.1.4",
-          "resolved": false,
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "bundled": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4440,29 +4422,25 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+          "version": "3.0.3",
+          "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -4470,13 +4448,11 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+          "bundled": true
         },
         "invert-kv": {
           "version": "1.0.0",
@@ -4485,16 +4461,14 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "bundled": true
         },
         "lcid": {
           "version": "1.0.0",
@@ -4506,58 +4480,50 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "bundled": true
         },
         "minipass": {
-          "version": "2.3.5",
-          "resolved": false,
-          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "version": "2.9.0",
+          "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+          "version": "1.3.3",
+          "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "requires": {
             "minimist": "0.0.8"
           },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "bundled": true
             }
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "bundled": true
         },
         "needle": {
           "version": "2.4.0",
-          "resolved": false,
-          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+          "bundled": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -4565,9 +4531,8 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.13.0",
-          "resolved": false,
-          "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
+          "version": "0.14.0",
+          "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -4578,13 +4543,12 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "bundled": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -4592,13 +4556,11 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+          "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.4",
-          "resolved": false,
-          "integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
+          "version": "1.4.6",
+          "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -4606,8 +4568,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -4617,26 +4578,22 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+          "bundled": true
         },
         "os-locale": {
           "version": "1.4.0",
@@ -4648,13 +4605,11 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -4662,13 +4617,11 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+          "bundled": true
         },
         "protobufjs": {
           "version": "5.0.3",
@@ -4683,8 +4636,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "bundled": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -4694,8 +4646,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "bundled": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4708,46 +4659,38 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": false,
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "bundled": true,
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+          "bundled": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+          "bundled": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4756,33 +4699,29 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+          "bundled": true
         },
         "tar": {
-          "version": "4.4.10",
-          "resolved": false,
-          "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
+          "version": "4.4.13",
+          "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
+            "minipass": "^2.8.6",
             "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
@@ -4791,21 +4730,18 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "bundled": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "bundled": true
         },
         "y18n": {
           "version": "3.2.1",
@@ -4813,9 +4749,8 @@
           "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
-          "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "version": "3.1.1",
+          "bundled": true
         },
         "yargs": {
           "version": "3.32.0",
@@ -4833,10 +4768,21 @@
         }
       }
     },
+    "grpc-health-check": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/grpc-health-check/-/grpc-health-check-1.7.0.tgz",
+      "integrity": "sha512-yrjWW9OLalYfF1BPXn0uMgiVqpma8AoNckeoJTAfCngexkbNH6l4C1+ACC6o0AD5AoH9OrbHyzdzM8IxvMGgJA==",
+      "requires": {
+        "google-protobuf": "^3.4.0",
+        "grpc": "^1.6.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "grpc-web": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.0.6.tgz",
-      "integrity": "sha512-iwqchQXNsA8bcJwuYEv/A8ScEaf5nA5+vtptEv2KN646KW94tsq7O+Q7hy5+gADOg6XhmJqPhSlvTMdiHlVfcw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.0.7.tgz",
+      "integrity": "sha512-Fkbz1nyvvt6GC6ODcxh9Fen6LLB3OTCgGHzHwM2Eni44SUhzqPz1UQgFp9sfBEfInOhx3yBdwo9ZLjZAmJ+TtA=="
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -4959,7 +4905,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -5276,8 +5221,7 @@
     "is-buffer": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
-      "dev": true
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -5761,12 +5705,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
-      "dev": true
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5778,21 +5716,15 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
-    "lodash.merge": {
+    "lodash.mergewith": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.set": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-    },
-    "lodash.snakecase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -5905,7 +5837,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -6282,6 +6213,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "multihashes": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.15.tgz",
+      "integrity": "sha512-G/Smj1GWqw1RQP3dRuRRPe3oyLqvPqUaEDIaoi7JF7Loxl4WAWvhJNk84oyDEodSucv0MmSW/ZT0RKUrsIFD3g==",
+      "requires": {
+        "bs58": "^4.0.1",
+        "varint": "^5.0.0"
+      }
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -6429,17 +6369,6 @@
             }
           }
         }
-      }
-    },
-    "nodeforage": {
-      "version": "git+https://github.com/Alex-Werner/nodeForage.git#57823e4f883754c56827fc2df2e70e26f9382790",
-      "from": "git+https://github.com/Alex-Werner/nodeForage.git",
-      "dev": true,
-      "requires": {
-        "lodash.find": "^4.6.0",
-        "lodash.merge": "^4.6.1",
-        "proper-lockfile": "^3.2.0",
-        "slocket": "^1.0.5"
       }
     },
     "nofilter": {
@@ -7010,7 +6939,6 @@
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-      "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -7073,17 +7001,6 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
-    },
-    "proper-lockfile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.2.0.tgz",
-      "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "retry": "^0.12.0",
-        "signal-exit": "^3.0.2"
-      }
     },
     "protobufjs": {
       "version": "6.8.8",
@@ -7566,12 +7483,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
-    },
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7591,7 +7502,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -7776,7 +7686,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -7941,17 +7850,6 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
-      }
-    },
-    "slocket": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/slocket/-/slocket-1.0.5.tgz",
-      "integrity": "sha1-kazYX5mmJ7u1q1B0psj9JLLxFlk=",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.4.7",
-        "rimraf": "^2.5.4",
-        "signal-exit": "^3.0.2"
       }
     },
     "snapdragon": {
@@ -9047,6 +8945,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",
     "mocha": "^6.2.0",
-    "nodeforage": "git+https://github.com/Alex-Werner/nodeForage.git",
     "nyc": "^14.1.1",
     "size-limit": "^2.1.4",
     "webpack": "^4.41.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@dashevo/dapi-client": "^0.7.0",
     "@dashevo/dashcore-lib": "^0.18.0",
     "@dashevo/dpp": "^0.9.1",
-    "bls-signatures": "^0.1.9",
     "cbor": "^5.0.1",
     "crypto-js": "^3.1.9-1",
     "localforage": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
   },
   "homepage": "https://github.com/dashevo/wallet-lib#readme",
   "dependencies": {
-    "@dashevo/dapi-client": "^0.6.7",
+    "@dashevo/dapi-client": "^0.7.0",
     "@dashevo/dashcore-lib": "^0.18.0",
-    "@dashevo/dpp": "^0.7.2",
+    "@dashevo/dpp": "^0.9.1",
     "bls-signatures": "^0.1.9",
     "cbor": "^5.0.1",
     "crypto-js": "^3.1.9-1",
     "localforage": "^1.7.3",
     "lodash": "^4.17.15",
     "winston": "^3.2.1",
-    "pbkdf2": "latest"
+    "pbkdf2": "^3.0.17"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "unpkg": "dist/wallet-lib.min.js",

--- a/src/CONSTANTS.js
+++ b/src/CONSTANTS.js
@@ -10,6 +10,11 @@ const CONSTANTS = {
   BIP44_LIVENET_ROOT_PATH: "m/44'/5'",
   // All testnet coins are 1's
   BIP44_TESTNET_ROOT_PATH: "m/44'/1'",
+
+  // Livenet is 5 for Dash.
+  DIP9_LIVENET_ROOT_PATH: "m/9'/5'",
+  // All testnet coins are 1's
+  DIP9_TESTNET_ROOT_PATH: "m/9'/1'",
   // The max amount of an UTXO to be considered too big to be used in the tx before exploring
   // smaller alternatives (proportinal to tx amount).
   UTXO_SELECTION_MAX_SINGLE_UTXO_FACTOR: 2,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,5 +3,19 @@
 /// <reference path="types/Wallet/Wallet.d.ts" />
 import { Account } from "./types/Account/Account";
 import { Wallet } from "./types/Wallet/Wallet";
-export { Account, Wallet };
+import { KeyChain } from "./types/KeyChain/KeyChain";
+import CONSTANTS from "./CONSTANTS";
+import EVENTS from "./EVENTS";
+import utils from "./utils";
+import plugins from "./plugins";
+
+export {
+    Account,
+    Wallet,
+    KeyChain,
+    EVENTS,
+    CONSTANTS,
+    utils,
+    plugins,
+};
 declare module '@dashevo/wallet-lib';

--- a/src/transports/Transporter.js
+++ b/src/transports/Transporter.js
@@ -48,7 +48,7 @@ class Transporter {
           // TODO : Remove me toward release
           if (transportArg === 'dapi') {
             transport = new DAPIClient({
-              seeds: [{ service: '34.221.111.151:3000' }],
+              seeds: [{ service: '18.236.131.253:3000' }],
               timeout: 20000,
               retries: 5,
             });

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -4,6 +4,7 @@ import {KeyChain} from "../KeyChain/KeyChain";
 export declare class Account {
     constructor(options?: Account.Options);
     keyChain: KeyChain;
+    state:any;
 
     isReady(): Promise<boolean>;
     isInitialized(): Promise<boolean>;

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -1,4 +1,5 @@
 import {Mnemonic, Transaction, AddressObj,AddressInfo, AddressType, transactionId, TransactionInfo, PublicAddress, PrivateKey, Strategy, Network, Plugins} from "../types";
+import {KeyChain} from "../KeyChain/KeyChain";
 
 export declare class Account {
     constructor(options?: Account.Options);
@@ -32,7 +33,7 @@ export declare class Account {
     getTransaction(txid: transactionId): Transaction;
     getTransactionHistory(): [object];
     getTransactions(): [Transaction];
-    getUnusedAddress(): AddressObj;
+    getUnusedAddress(type?: AddressType, skip?: number): AddressObj;
     getUTXOS(): [object];
     injectPlugin(unsafePlugin: Plugins, allowSensitiveOperation:boolean): Promise<boolean>;
     sign(object?:Transaction, privateKeys?:[PrivateKey], sigType?:string): Transaction;

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -3,6 +3,7 @@ import {KeyChain} from "../KeyChain/KeyChain";
 
 export declare class Account {
     constructor(options?: Account.Options);
+    index: number;
     keyChain: KeyChain;
     state:any;
 

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -5,6 +5,8 @@ export declare class Account {
     constructor(options?: Account.Options);
     keyChain: KeyChain;
 
+    isReady(): Promise<boolean>;
+    isInitialized(): Promise<boolean>;
     broadcastTransaction(rawtx: string, isIS?: boolean): Promise<transactionId>;
     connect(): boolean;
     createTransaction(opts: Account.createTransactionOptions): Transaction;

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -2,6 +2,7 @@ import {Mnemonic, Transaction, AddressObj,AddressInfo, AddressType, transactionI
 
 export declare class Account {
     constructor(options?: Account.Options);
+    keyChain: KeyChain;
 
     broadcastTransaction(rawtx: string, isIS?: boolean): Promise<transactionId>;
     connect(): boolean;

--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -31,9 +31,9 @@ class Account {
     this.walletId = wallet.walletId;
 
     this.events = new EventEmitter();
-    this.isReady = false;
     this.state = {
       isInitialized: false,
+      isReady: false,
       isDisconnecting: false,
     };
     this.injectDefaultPlugins = _.has(opts, 'injectDefaultPlugins') ? opts.injectDefaultPlugins : defaultOptions.injectDefaultPlugins;

--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -32,8 +32,10 @@ class Account {
 
     this.events = new EventEmitter();
     this.isReady = false;
-    this.isInitialized = false;
-    this.isDisconnecting = false;
+    this.state = {
+      isInitialized: false,
+      isDisconnecting: false,
+    };
     this.injectDefaultPlugins = _.has(opts, 'injectDefaultPlugins') ? opts.injectDefaultPlugins : defaultOptions.injectDefaultPlugins;
     this.allowSensitiveOperations = _.has(opts, 'allowSensitiveOperations') ? opts.allowSensitiveOperations : defaultOptions.allowSensitiveOperations;
 
@@ -117,6 +119,22 @@ class Account {
     // (and therefore push to accounts).
     _addAccountToWallet(this, wallet);
     _initializeAccount(this, wallet.plugins);
+  }
+
+  async isInitialized() {
+    // eslint-disable-next-line consistent-return
+    return new Promise(((resolve) => {
+      if (this.state.isInitialized) return resolve(true);
+      this.events.on(EVENTS.INITIALIZED, () => resolve(true));
+    }));
+  }
+
+  async isReady() {
+    // eslint-disable-next-line consistent-return
+    return new Promise(((resolve) => {
+      if (this.state.isReady) return resolve(true);
+      this.events.on(EVENTS.READY, () => resolve(true));
+    }));
   }
 }
 

--- a/src/types/Account/_initializeAccount.js
+++ b/src/types/Account/_initializeAccount.js
@@ -57,9 +57,9 @@ async function _initializeAccount(account, userUnsafePlugins) {
       }
     };
     const sendInitialized = () => {
-      if (!self.isInitialized) {
+      if (!self.state.isInitialized) {
         self.events.emit(EVENTS.INITIALIZED);
-        self.isInitialized = true;
+        self.state.isInitialized = true;
       }
     };
 

--- a/src/types/Account/_initializeAccount.js
+++ b/src/types/Account/_initializeAccount.js
@@ -51,9 +51,9 @@ async function _initializeAccount(account, userUnsafePlugins) {
     self.events.emit(EVENTS.STARTED);
 
     const sendReady = () => {
-      if (!self.isReady) {
+      if (!self.state.isReady) {
         self.events.emit(EVENTS.READY);
-        self.isReady = true;
+        self.state.isReady = true;
       }
     };
     const sendInitialized = () => {

--- a/src/types/KeyChain/KeyChain.d.ts
+++ b/src/types/KeyChain/KeyChain.d.ts
@@ -1,5 +1,5 @@
 import {PrivateKey, Network,} from "../types";
-import {HDPrivateKey} from "@dashevo/dashcore-lib";
+import {HDPrivateKey, HDPublicKey} from "@dashevo/dashcore-lib";
 
 export declare class KeyChain {
     constructor(options?: KeyChain.Options);
@@ -12,24 +12,22 @@ export declare class KeyChain {
     privateKey?: PrivateKey;
 
 
-    generateKeyForChild(index: number, type: HDKeyTypesParam): HDKeyTypes;
-    generateKeyForPath(path: string, type: HDKeyTypesParam): HDKeyTypes;
+    generateKeyForChild(index: number, type?: HDKeyTypesParam): HDPrivateKey|HDPublicKey;
+    generateKeyForPath(path: string, type?: HDKeyTypesParam): HDKeyTypes;
 
-    getHardenedBIP44Path(): string;
-    getHardenedDIP9FeaturePath(): string;
+    getHardenedBIP44Path(type?: HDKeyTypesParam): HDKeyTypes;
+    getHardenedDIP9FeaturePath(type?: HDKeyTypesParam): HDKeyTypes;
 
-    getKeyForChild(index: number, type: HDKeyTypesParam): HDKeyTypes;
-    getKeyForPath(path: string, type: HDKeyTypesParam): HDKeyTypes;
+    getKeyForChild(index: number, type?: HDKeyTypesParam): HDKeyTypes;
+    getKeyForPath(path: string, type?: HDKeyTypesParam): HDKeyTypes;
     getPrivateKey(): HDPrivateKey|PrivateKey;
 
     // TODO : dashcore-lib miss an implementation definition of crypto.Signature
     sign(object: any, privateKeys:[any], sigType: object): any;
 
 }
-export declare enum HDKeyTypes {
-    HDPrivateKey,
-    HDPublicKey,
-}
+type HDKeyTypes = HDPublicKey | HDPrivateKey;
+
 export declare enum HDKeyTypesParam {
     HDPrivateKey="HDPrivateKey",
     HDPublicKey="HDPrivateKey",

--- a/src/types/KeyChain/KeyChain.d.ts
+++ b/src/types/KeyChain/KeyChain.d.ts
@@ -1,0 +1,49 @@
+import {PrivateKey, Network,} from "../types";
+import {HDPrivateKey} from "@dashevo/dashcore-lib";
+
+export declare class KeyChain {
+    constructor(options?: KeyChain.Options);
+    network: Network;
+    keys: [Keys];
+
+    // todo valid keychain type object.
+    type: string;
+    HDPrivateKey?: HDPrivateKey;
+    privateKey?: PrivateKey;
+
+
+    generateKeyForChild(index: number, type: HDKeyTypesParam): HDKeyTypes;
+    generateKeyForPath(path: string, type: HDKeyTypesParam): HDKeyTypes;
+
+    getHardenedBIP44Path(): string;
+    getHardenedDIP9FeaturePath(): string;
+
+    getKeyForChild(index: number, type: HDKeyTypesParam): HDKeyTypes;
+    getKeyForPath(path: string, type: HDKeyTypesParam): HDKeyTypes;
+    getPrivateKey(): HDPrivateKey|PrivateKey;
+
+    // TODO : dashcore-lib miss an implementation definition of crypto.Signature
+    sign(object: any, privateKeys:[any], sigType: object): any;
+
+}
+export declare enum HDKeyTypes {
+    HDPrivateKey,
+    HDPublicKey,
+}
+export declare enum HDKeyTypesParam {
+    HDPrivateKey="HDPrivateKey",
+    HDPublicKey="HDPrivateKey",
+}
+export declare interface Keys {
+    [path: string]: {
+        path: string
+    };
+}
+export declare namespace KeyChain {
+    interface Options {
+        network?: Network;
+        keys?: [Keys]
+    }
+}
+
+

--- a/src/types/KeyChain/KeyChain.js
+++ b/src/types/KeyChain/KeyChain.js
@@ -34,7 +34,8 @@ class KeyChain {
 
 KeyChain.prototype.generateKeyForChild = require('./methods/generateKeyForChild');
 KeyChain.prototype.generateKeyForPath = require('./methods/generateKeyForPath');
-KeyChain.prototype.getHardenedFeaturePath = require('./methods/getHardenedFeaturePath');
+KeyChain.prototype.getHardenedBIP44Path = require('./methods/getHardenedBIP44Path');
+KeyChain.prototype.getHardenedDIP9FeaturePath = require('./methods/getHardenedDIP9FeaturePath');
 KeyChain.prototype.getKeyForChild = require('./methods/getKeyForChild');
 KeyChain.prototype.getKeyForPath = require('./methods/getKeyForPath');
 KeyChain.prototype.getPrivateKey = require('./methods/getPrivateKey');

--- a/src/types/KeyChain/methods/getHardenedBIP44Path.js
+++ b/src/types/KeyChain/methods/getHardenedBIP44Path.js
@@ -2,10 +2,10 @@ const { BIP44_TESTNET_ROOT_PATH, BIP44_LIVENET_ROOT_PATH } = require('../../../C
 
 /**
  * Return a safier root path to derivate from
- *
+ * @param type - {HDPrivateKey|HDPublicKey} def : HDPrivateKey - set the type of returned keys
  */
-function getHardenedBIP44Path() {
+function getHardenedBIP44Path(type = 'HDPrivateKey') {
   const pathRoot = (this.network.toString() === 'testnet') ? BIP44_TESTNET_ROOT_PATH : BIP44_LIVENET_ROOT_PATH;
-  return this.generateKeyForPath(pathRoot);
+  return this.generateKeyForPath(pathRoot, type);
 }
 module.exports = getHardenedBIP44Path;

--- a/src/types/KeyChain/methods/getHardenedBIP44Path.js
+++ b/src/types/KeyChain/methods/getHardenedBIP44Path.js
@@ -4,8 +4,8 @@ const { BIP44_TESTNET_ROOT_PATH, BIP44_LIVENET_ROOT_PATH } = require('../../../C
  * Return a safier root path to derivate from
  *
  */
-function getHardenedFeaturePath() {
+function getHardenedBIP44Path() {
   const pathRoot = (this.network.toString() === 'testnet') ? BIP44_TESTNET_ROOT_PATH : BIP44_LIVENET_ROOT_PATH;
   return this.generateKeyForPath(pathRoot);
 }
-module.exports = getHardenedFeaturePath;
+module.exports = getHardenedBIP44Path;

--- a/src/types/KeyChain/methods/getHardenedDIP9FeaturePath.js
+++ b/src/types/KeyChain/methods/getHardenedDIP9FeaturePath.js
@@ -1,0 +1,11 @@
+const { DIP9_LIVENET_ROOT_PATH, DIP9_TESTNET_ROOT_PATH } = require('../../../CONSTANTS');
+
+/**
+ * Return a safier root path to derivate from
+ *
+ */
+function getHardenedDIP9FeaturePath() {
+  const pathRoot = (this.network.toString() === 'testnet') ? DIP9_TESTNET_ROOT_PATH : DIP9_LIVENET_ROOT_PATH;
+  return this.generateKeyForPath(pathRoot);
+}
+module.exports = getHardenedDIP9FeaturePath;

--- a/src/types/KeyChain/methods/getHardenedDIP9FeaturePath.js
+++ b/src/types/KeyChain/methods/getHardenedDIP9FeaturePath.js
@@ -2,10 +2,10 @@ const { DIP9_LIVENET_ROOT_PATH, DIP9_TESTNET_ROOT_PATH } = require('../../../CON
 
 /**
  * Return a safier root path to derivate from
- *
+ * @param type - {HDPrivateKey|HDPublicKey} def : HDPrivateKey - set the type of returned keys
  */
-function getHardenedDIP9FeaturePath() {
+function getHardenedDIP9FeaturePath(type = 'HDPrivateKey') {
   const pathRoot = (this.network.toString() === 'testnet') ? DIP9_TESTNET_ROOT_PATH : DIP9_LIVENET_ROOT_PATH;
-  return this.generateKeyForPath(pathRoot);
+  return this.generateKeyForPath(pathRoot, type);
 }
 module.exports = getHardenedDIP9FeaturePath;

--- a/src/types/Wallet/Wallet.d.ts
+++ b/src/types/Wallet/Wallet.d.ts
@@ -32,7 +32,7 @@ export declare namespace Wallet {
         plugins?: [Plugins];
         passphrase?: string;
         injectDefaultPlugins?: boolean;
-        mnemonic?: Mnemonic|string;
+        mnemonic?: Mnemonic|string|null;
         seed?: Mnemonic|string;
         privateKey?: PrivateKey|string;
         HDPrivateKey?: HDPrivateKey|string;

--- a/src/types/Wallet/Wallet.js
+++ b/src/types/Wallet/Wallet.js
@@ -66,7 +66,7 @@ class Wallet {
     this.network = Dashcore.Networks[network].toString();
 
     if ('mnemonic' in opts) {
-      this.fromMnemonic(opts.mnemonic);
+      this.fromMnemonic((opts.mnemonic === null) ? generateNewMnemonic() : opts.mnemonic);
     } else if ('seed' in opts) {
       this.fromSeed(opts.seed);
     } else if ('HDPrivateKey' in opts) {

--- a/test/types/Account/Account.js
+++ b/test/types/Account/Account.js
@@ -39,7 +39,7 @@ describe('Account - class', () => {
     expect(account.index).to.be.deep.equal(0);
     expect(account.injectDefaultPlugins).to.be.deep.equal(false);
     expect(account.allowSensitiveOperations).to.be.deep.equal(false);
-    expect(account.isReady).to.be.deep.equal(false);
+    expect(account.state.isReady).to.be.deep.equal(false);
     expect(account.type).to.be.deep.equal(undefined);
     expect(account.transactions).to.be.deep.equal({});
     expect(account.label).to.be.deep.equal(null);

--- a/test/types/KeyChain/KeyChain.js
+++ b/test/types/KeyChain/KeyChain.js
@@ -27,12 +27,12 @@ describe('Keychain', () => {
     expect(address).to.equal('yNfUebksUc5HoSfg8gv98ruC3jUNJUM8pT');
   });
   it('should get hardened feature path', () => {
-    const hardenedPk = keychain.getHardenedFeaturePath();
+    const hardenedPk = keychain.getHardenedBIP44Path();
     const pk2 = keychain.getKeyForPath('m/44\'/1\'');
     expect(pk2.toString()).to.equal(hardenedPk.toString());
   });
   it('should derive from hardened feature path', () => {
-    const hardenedPk = keychain.getHardenedFeaturePath();
+    const hardenedPk = keychain.getHardenedBIP44Path();
     const derivedPk = hardenedPk.deriveChild(0, true).deriveChild(0).deriveChild(0);
     const address = new Dashcore.Address(derivedPk.publicKey.toAddress()).toString();
     expect(address).to.equal('yNfUebksUc5HoSfg8gv98ruC3jUNJUM8pT');

--- a/test/types/Storage/methods/startWorker.js
+++ b/test/types/Storage/methods/startWorker.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const {expect} = require('chai');
 const startWorker = require('../../../../src/types/Storage/methods/startWorker');
 
 let testInterval = null;
@@ -23,7 +23,10 @@ describe('Storage - startWorker', function suite() {
   it('should works', async () => new Promise((res) => {
     let saved = 0;
     const self = {
-      saveState: () => { saved += 1; self.lastSave = Date.now(); },
+      saveState: () => {
+        saved += 1;
+        self.lastSave = Date.now();
+      },
       autosaveIntervalTime: 500,
       lastModified: Date.now(),
       lastSave: 0,
@@ -35,8 +38,10 @@ describe('Storage - startWorker', function suite() {
       clearInterval(self.interval);
       testInterval = clearInterval(testInterval);
 
+      expect(saved < 11).to.be.equal(true);
       // First autosave + 9 induced changes
-      res(expect(saved).to.be.equal(10));
+      // However it can be less as we do not hard force the place in the event loop (simple setInterval)
+      res(expect(saved >= 8).to.be.equal(true));
     }, 5499);
   }));
 });


### PR DESCRIPTION
### Issue being fixed or implemented  

With Evonet being released, Wallet-lib and DashJS have their MVP feature-set release. 
This PR brings the last required changes for enabling interaction with Evonet. 

### What was done  

- feat: added getHardenedDIP9FeaturePath
- feat: added account.isReady() and account.isInitialiazed() for syntaxic helper around events.on('ready')
- DAPI connectivity with Evonet
- Renamed `keyChain.getHardenedPath` to `keyChain.getHardenedBIP44Path`
- impr: generate new mnemonic when {mnemonic:null} is provided. 
- doc: KeyChain typings required for usage on DashJS

### How Has This Been Tested?

This PR had it's requirement driven by the usage on DashJS. Close work and various manual tests were provided on top of our test suite.

### Notes  

Most of the changes toward grpc is being done by our use of DAPI-Client. 

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
