### PR TITLE
chore: travis build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - "12"
 
 before_install:
-  - echo -e "machine github.com\n  login ${GH_TOKEN}" >> ~/.netrc
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 jobs:

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -14,5 +14,7 @@ if [ "$TRAVIS_NODE_VERSION" != "$LATEST_LTS_VERSION" ]; then
   exit 0
 fi
 
+npm run build:prod
+
 # Now that checks have been passed, publish the module
 npm publish


### PR DESCRIPTION
### Issue being fixed or implemented  

Removed our GH_Token : This is not required anymore, nothing is private.
Added npm run build before npm publish and removing current dist/* folder

### What was done  

- Removed GH_TOKEN in .travis.yml
- Modified travis-deploy with npm run build
- Removed folder dist

### Notes  

We used this to require our private repo, we do not need that anymore as all repos are now public. 