### PR TITLE
fix: confirmedBalance always empty

### DIFF
--- a/src/types/Storage/methods/updateAddress.js
+++ b/src/types/Storage/methods/updateAddress.js
@@ -38,7 +38,7 @@ const updateAddress = function (addressObj, walletId) {
   // if(newObject.utxos.length==0 && previousObject.utxos.length>0){
   //
   // }
-  const currentBlockHeight = this.store.chains[walletStore.network].blockHeight;
+  // const currentBlockHeight = this.store.chains[walletStore.network].blockHeight;
 
   // We calculate here the balanceSat and unconfirmedBalanceSat of our addressObj
   // We do that to avoid getBalance to be slow, so we have to keep that in mind or then
@@ -60,15 +60,13 @@ const updateAddress = function (addressObj, walletId) {
       utxo.outputIndex = parseInt(outputIndex, 10);
 
       try {
-        const { blockHeight } = this.getTransaction(txid);
-        if (currentBlockHeight - blockHeight >= 6) newObject.balanceSat += utxo.satoshis;
-        else newObject.unconfirmedBalanceSat += utxo.satoshis;
+        this.getTransaction(txid);
+        // TODO : We removed here the confirmations verification
+        // We should ensure we had a locked block before being able to really spend those.
+        newObject.balanceSat += utxo.satoshis;
       } catch (e) {
-        logger.error('Error', e);
-        if (e instanceof TransactionNotInStore) {
-          // TODO : We consider unconfirmed a transaction that we don't know of, should we ?
-          newObject.unconfirmedBalanceSat += utxo.satoshis;
-        } else throw e;
+        logger.error(`Unable to find locally ${txid}`);
+        throw new Error(e);
       }
     });
   }

--- a/src/types/Storage/methods/updateAddress.js
+++ b/src/types/Storage/methods/updateAddress.js
@@ -66,7 +66,7 @@ const updateAddress = function (addressObj, walletId) {
         newObject.balanceSat += utxo.satoshis;
       } catch (e) {
         logger.error(`Unable to find locally ${txid}`);
-        throw new Error(e);
+        if (!(e instanceof TransactionNotInStore)) throw new Error(e);
       }
     });
   }

--- a/src/types/Storage/methods/updateAddress.js
+++ b/src/types/Storage/methods/updateAddress.js
@@ -66,7 +66,7 @@ const updateAddress = function (addressObj, walletId) {
         newObject.balanceSat += utxo.satoshis;
       } catch (e) {
         logger.error(`Unable to find locally ${txid}`);
-        if (!(e instanceof TransactionNotInStore)) throw new Error(e);
+        if (!(e instanceof TransactionNotInStore)) throw e;
       }
     });
   }

--- a/test/z-integrations/sweepWallet.js
+++ b/test/z-integrations/sweepWallet.js
@@ -118,7 +118,7 @@ describe('Wallet - sweepWallet', function suite() {
         if (balance < 2500) throw new Error('Failed to fund wallet1');
         if (balance2 < 2500) throw new Error('Failed to fund wallet2');
         done();
-      }, 5000);
+      }, 9000);
     })();
   });
   it('should work', async () => {


### PR DESCRIPTION
### Issue being fixed or implemented  

With the removal of blockheight from block, we lost the ability to count the confirmation amount from a transaction. 
It had an effect on being able to pay in certains circonstances. 
This PR fixes that by always considering TX has spendable if they are in a block. 
We will need to take ClSig in consideration later on. 

### What was done  

- fix: assign balance to confirmedBalance for all tx 

### Notes  

We will need to add later on the verification for ClSig (chainlock)


### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
