### PR TITLE
fix: support for DAPIClient.getUTXO with more than 1000 utxos

### DIFF
--- a/src/transporters/types/DAPIClient/methods/getUTXO.js
+++ b/src/transporters/types/DAPIClient/methods/getUTXO.js
@@ -26,7 +26,7 @@ module.exports = async function getUTXO(address) {
     const promises = [];
     const numberOfPromises = Math.floor((firstRequest.totalItems - 1000) / 1000);
 
-    for (let i = 0; i < numberOfPromises; i++) {
+    for (let i = 0; i < numberOfPromises; i = +1) {
       from = to;
       to += 1000;
       promises.push(fetchAndReturnUTXO(from, to));

--- a/src/transporters/types/DAPIClient/methods/getUTXO.js
+++ b/src/transporters/types/DAPIClient/methods/getUTXO.js
@@ -4,5 +4,48 @@ const logger = require('../../../../logger');
 module.exports = async function getUTXO(address) {
   logger.silly(`DAPIClient.getUTXO[${address}]`);
   if (!is.address(address) && !is.arr(address)) throw new Error('Received an invalid address to fetch');
-  return this.client.getUTXO(address);
+
+  let from = 0;
+  let to = 1000;
+  let utxos = [];
+
+  const fetchAndReturnUTXO = async (_from, _to) => {
+    try {
+      const req = await this.client.getUTXO(address, _from, _to);
+      return { ...req, size: req.items.length };
+    } catch (e) {
+      logger.error(`Error fetching UTXO ${address}:{_from}:{_to} - ${e.message}`);
+      throw e;
+    }
+  };
+
+  const firstRequest = await fetchAndReturnUTXO(from, to);
+  utxos = utxos.concat(firstRequest.items);
+
+  if (firstRequest.totalItems > firstRequest.to) {
+    const promises = [];
+    const numberOfPromises = Math.floor((firstRequest.totalItems - 1000) / 1000);
+
+    for (let i = 0; i < numberOfPromises; i++) {
+      from = to;
+      to += 1000;
+      promises.push(fetchAndReturnUTXO(from, to));
+    }
+
+    const rest = ((firstRequest.totalItems + 1 + numberOfPromises) % 1000);
+    if (rest) {
+      from = to;
+      to += rest;
+      promises.push(fetchAndReturnUTXO(from, to));
+    }
+
+    const resolvedPromises = await Promise.all(promises);
+    resolvedPromises.forEach((res) => {
+      if (res.items) {
+        utxos = utxos.concat(res.items);
+      }
+    });
+  }
+
+  return utxos;
 };

--- a/src/transporters/types/DAPIClient/methods/subscribeToAddressesTransactions.js
+++ b/src/transporters/types/DAPIClient/methods/subscribeToAddressesTransactions.js
@@ -26,7 +26,7 @@ async function executor(forcedAddressList = null) {
     fetchedUtxos[address] = [];
   });
 
-  const utxos = (await self.getUTXO(addressList)).items;
+  const utxos = (await self.getUTXO(addressList));
 
   utxos.forEach((utxo) => {
     const { address, txid, outputIndex } = utxo;

--- a/src/types/Account/methods/fetchAddressInfo.js
+++ b/src/types/Account/methods/fetchAddressInfo.js
@@ -52,10 +52,8 @@ async function fetchAddressInfo(addressObj, fetchUtxo = true) {
       }
     }
     if (fetchUtxo) {
-      const fetchedUtxoReq = await self.transporter.getUTXO(address);
-      if (fetchedUtxoReq && fetchedUtxoReq.totalItems) {
-        const fetchedUtxo = fetchedUtxoReq.items;
-
+      const fetchedUtxo = await self.transporter.getUTXO(address);
+      if (fetchedUtxo.length) {
         const utxos = [];
         if (balanceSat > 0) {
           fetchedUtxo.forEach((utxo) => {

--- a/test/transporters/types/DAPIClient/methods/getUTXO.spec.js
+++ b/test/transporters/types/DAPIClient/methods/getUTXO.spec.js
@@ -21,6 +21,6 @@ describe('transporters - DAPIClient - .getUTXO', () => {
   it('should works', async () => {
     transporter.client.getUTXO = () => fixture;
     const res = await transporter.getUTXO('yYpSw2n2TRzoQaUShNsPo541z4bz4EJkGN');
-    expect(res).to.deep.equal(fixture);
+    expect(res).to.deep.equal(fixture.items);
   });
 });


### PR DESCRIPTION
### Issue being fixed or implemented  

In the rush of 6.0.0, we had to delay support for 1000 utxo based wallet. 
This brings back the support for those cases. 
 
### What was done  

- impr: parallelized requests to multiple dapi node for the different range (per 1000utxos)
- breaking: internal breaking change .transporter.getUTXO now only returns the utxos list (Object > Array[utxos])

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
