### PR TITLE
build: moved npm access_token from before_install to before_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,19 @@ node_js:
   - "12"
   - "14"
 
-branches:
+branches: 
   only:
     - master
     - develop
-
-before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 script:
   - npm run check-package
   - npm run build:prod
   - npm run test
+
+before_deploy:
+  # Add token for @dashevo private npm registry & deployement
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 deploy:
   - provider: script


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently PRs from external repos cannot successfully run tests because Travis prevents them from accessing the NPM token. In the same way, we do not need it in the before_install as we do not have any private repo anymore.

## What was done?
<!--- Describe your changes in detail -->
Only require npm on deployment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This was used in dashevo/dapi-grpc#61 and  dashevo/dashjs#66. Expecting good results based on previous results there.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation
