### PR TITLE
build: allow travis build request on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ node_js:
   - "12"
   - "14"
 
-branches: 
+branches:
   only:
     - master
     - develop
+    - /^v(\d+\.)?(\d+\.)?(\*|\d+)$/
 
 script:
   - npm run check-package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now, when github request a build, due to our .travis.yml only accepting develop and master, any tags (v.x.x.x) would not be ran, and therefore we would not see it being deploy. 
This PR fixes that. 


## What was done?
<!--- Describe your changes in detail -->
- added regex for tags on `branches.only:`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation
