### PR TITLE
impr!: removed eventemitter2

### DIFF
--- a/src/plugins/StandardPlugin.js
+++ b/src/plugins/StandardPlugin.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { EventEmitter2: EventEmitter } = require('eventemitter2');
+const EventEmitter = require('events');
 const { InjectionToPluginUnallowed } = require('../errors');
 const { SAFE_FUNCTIONS, SAFE_PROPERTIES } = require('../CONSTANTS').INJECTION_LISTS;
 
@@ -9,7 +9,7 @@ const defaultOpts = {
 
 class StandardPlugin extends EventEmitter {
   constructor(opts = {}) {
-    super({ wildcard: true });
+    super();
     this.pluginType = _.has(opts, 'type') ? opts.type : 'Standard';
     this.name = _.has(opts, 'name') ? opts.name : 'UnnamedPlugin';
     this.dependencies = _.has(opts, 'dependencies') ? opts.dependencies : [];

--- a/src/transporters/types/BaseTransporter/BaseTransporter.js
+++ b/src/transporters/types/BaseTransporter/BaseTransporter.js
@@ -1,4 +1,4 @@
-const { EventEmitter2: EventEmitter } = require('eventemitter2');
+const EventEmitter = require('events');
 
 class BaseTransporter extends EventEmitter {
   constructor(props) {

--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const { EventEmitter2: EventEmitter } = require('eventemitter2');
+const EventEmitter = require('events');
 const logger = require('../../logger');
 const { WALLET_TYPES } = require('../../CONSTANTS');
 const { is } = require('../../utils');
@@ -48,7 +48,7 @@ const getBIP44Path = require('./_getBIP44Path');
 
 class Account extends EventEmitter {
   constructor(wallet, opts = defaultOptions) {
-    super({ wildcard: true });
+    super();
     if (!wallet || wallet.constructor.name !== Wallet.name) throw new Error('Expected wallet to be passed as param');
     if (!_.has(wallet, 'walletId')) throw new Error('Missing walletID to create an account');
     this.walletId = wallet.walletId;

--- a/src/types/Storage/Storage.js
+++ b/src/types/Storage/Storage.js
@@ -1,4 +1,4 @@
-const { EventEmitter2: EventEmitter } = require('eventemitter2');
+const EventEmitter = require('events');
 const { cloneDeep, has } = require('lodash');
 
 const CONSTANTS = require('../../CONSTANTS');
@@ -22,7 +22,7 @@ const _defaultOpts = {
  * */
 class Storage extends EventEmitter {
   constructor(opts = JSON.parse(JSON.stringify(_defaultOpts))) {
-    super({ wildcard: true });
+    super();
     const defaultOpts = JSON.parse(JSON.stringify(_defaultOpts));
 
     this.store = cloneDeep(initialStore);


### PR DESCRIPTION
## Issue being fixed or feature implemented

In Wallet-lib eventemitter2 feature are not used, they are only for users. 
Sadly, in DashJS post-compile, we face a blocking issue with this library that blocks further release, and therefore we remove it.

## What was done?

- chore: removed eventemitter2

## How Has This Been Tested?
- Using test suite


## Breaking Changes

- Users won't be able to use wildcard and delimiter feature of Events.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation
