### PR TITLE
fix: broadcastTransaction not throwing an error when a transaction wasn't broadcasted

### DIFF
--- a/src/types/Account/methods/broadcastTransaction.js
+++ b/src/types/Account/methods/broadcastTransaction.js
@@ -40,36 +40,32 @@ function impactAffectedInputs({ inputs }) {
  */
 // FIXME : IsIS needs to be removed.
 async function broadcastTransaction(transaction) {
-  try {
-    if (!this.transporter.isValid) throw new ValidTransportLayerRequired('broadcast');
+  if (!this.transporter.isValid) throw new ValidTransportLayerRequired('broadcast');
 
-    // We still support having in rawtransaction, if this is the case
-    // we first need to reform our object
-    if (is.string(transaction)) {
-      const rawtx = transaction.toString();
-      if (!is.rawtx(rawtx)) throw new InvalidRawTransaction(rawtx);
-      return broadcastTransaction.call(this, new Dashcore.Transaction(rawtx));
-    }
-
-    if (!is.dashcoreTransaction(transaction)) {
-      throw new InvalidDashcoreTransaction(transaction);
-    }
-
-    if (!transaction.isFullySigned()) {
-      throw new Error('Transaction not signed.');
-    }
-    const txid = await this.transporter.sendTransaction(transaction.toString());
-    // We now need to impact/update our affected inputs
-    // so we clear them out from UTXOset.
-    const { inputs } = new Dashcore.Transaction(transaction).toObject();
-    impactAffectedInputs.call(this, {
-      inputs,
-    });
-
-    return txid;
-  } catch (e) {
-    return e;
+  // We still support having in rawtransaction, if this is the case
+  // we first need to reform our object
+  if (is.string(transaction)) {
+    const rawtx = transaction.toString();
+    if (!is.rawtx(rawtx)) throw new InvalidRawTransaction(rawtx);
+    return broadcastTransaction.call(this, new Dashcore.Transaction(rawtx));
   }
+
+  if (!is.dashcoreTransaction(transaction)) {
+    throw new InvalidDashcoreTransaction(transaction);
+  }
+
+  if (!transaction.isFullySigned()) {
+    throw new Error('Transaction not signed.');
+  }
+  const txid = await this.transporter.sendTransaction(transaction.toString());
+  // We now need to impact/update our affected inputs
+  // so we clear them out from UTXOset.
+  const { inputs } = new Dashcore.Transaction(transaction).toObject();
+  impactAffectedInputs.call(this, {
+    inputs,
+  });
+
+  return txid;
 }
 
 module.exports = broadcastTransaction;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`broadcastTransaction` not throwing an error when a transaction wasn't broadcasted

## What was done?
<!--- Describe your changes in detail -->
Removed `try{} catch(){}` that was supressing the error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
-

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
