### PR TITLE
fix(Storage): identityIds being restate to empty array

### DIFF
--- a/src/types/Storage/methods/insertIdentityAtIndex.js
+++ b/src/types/Storage/methods/insertIdentityAtIndex.js
@@ -7,7 +7,7 @@ const IdentityReplaceError = require('../../../errors/IndentityIdReplaceError');
  * @param {number} identityIndex
  */
 function insertIdentityAtIndex(walletId, identityId, identityIndex) {
-  if (this.store.wallets[walletId].identityIds) {
+  if (!this.store.wallets[walletId].identityIds) {
     this.store.wallets[walletId].identityIds = [];
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When inserting a new identity at a specific index, we were resetting the identityIds array to empty array. 
This PR fixes that bug.

## What was done?
<!--- Describe your changes in detail -->
- fix: identityIds being restate to empty array

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation
