### PR TITLE
fix: comportement on new address with existing transaction in store

### DIFF
--- a/src/plugins/Workers/BIP44Worker/ensureEnoughAddress.js
+++ b/src/plugins/Workers/BIP44Worker/ensureEnoughAddress.js
@@ -1,56 +1,9 @@
 const { BIP44_ADDRESS_GAP, WALLET_TYPES } = require('../../../CONSTANTS');
 const is = require('../../../utils/is');
 
-const isContiguousPath = (currPath, prevPath) => {
-  if (is.undef(currPath)) return false;
-  const splitedCurrPath = currPath.split('/');
-  const currIndex = parseInt(splitedCurrPath[5], 10);
-  if (is.undef(prevPath)) {
-    if (currIndex !== 0) return false;
-    return true;
-  }
-  const splitedPrevPath = prevPath.split('/');
-  const prevIndex = parseInt(splitedPrevPath[5], 10);
-  if (prevIndex !== currIndex - 1) return false;
-  return true;
-};
-const getMissingIndexes = (paths, fromOrigin = true) => {
-  if (!is.arr(paths)) return false;
+const getMissingIndexes = require('./utils/getMissingIndexes');
+const isContiguousPath = require('./utils/isContiguousPath');
 
-  let sortedIndexes = [];
-
-  paths.forEach((path) => {
-    const splitedPath = path.split('/');
-    const index = parseInt(splitedPath[5], 10);
-    sortedIndexes.push(index);
-  });
-
-  sortedIndexes = sortedIndexes.sort((a, b) => a - b);
-
-  let missingIndex = sortedIndexes.reduce((acc, cur, ind, arr) => {
-    const diff = cur - arr[ind - 1];
-    if (diff > 1) {
-      let i = 1;
-      while (i < diff) {
-        acc.push(arr[ind - 1] + i);
-        i += 1;
-      }
-    }
-    return acc;
-  }, []);
-
-  // Will fix missing index before our first known indexes
-  if (fromOrigin) {
-    if (sortedIndexes[0] > 0) {
-      for (let i = sortedIndexes[0] - 1; i >= 0; i -= 1) {
-        missingIndex.push(i);
-      }
-    }
-  }
-
-  missingIndex = missingIndex.sort((a, b) => a - b);
-  return missingIndex;
-};
 module.exports = function ensureEnoughAddress() {
   let generated = 0;
   let unusedAddress = 0;

--- a/src/plugins/Workers/BIP44Worker/utils/getMissingIndexes.js
+++ b/src/plugins/Workers/BIP44Worker/utils/getMissingIndexes.js
@@ -1,0 +1,39 @@
+const is = require('../../../../utils/is');
+
+module.exports = function getMissingIndexes(paths, fromOrigin = true) {
+  if (!is.arr(paths)) return false;
+
+  let sortedIndexes = [];
+
+  paths.forEach((path) => {
+    const splitedPath = path.split('/');
+    const index = parseInt(splitedPath[5], 10);
+    sortedIndexes.push(index);
+  });
+
+  sortedIndexes = sortedIndexes.sort((a, b) => a - b);
+
+  let missingIndex = sortedIndexes.reduce((acc, cur, ind, arr) => {
+    const diff = cur - arr[ind - 1];
+    if (diff > 1) {
+      let i = 1;
+      while (i < diff) {
+        acc.push(arr[ind - 1] + i);
+        i += 1;
+      }
+    }
+    return acc;
+  }, []);
+
+  // Will fix missing index before our first known indexes
+  if (fromOrigin) {
+    if (sortedIndexes[0] > 0) {
+      for (let i = sortedIndexes[0] - 1; i >= 0; i -= 1) {
+        missingIndex.push(i);
+      }
+    }
+  }
+
+  missingIndex = missingIndex.sort((a, b) => a - b);
+  return missingIndex;
+};

--- a/src/plugins/Workers/BIP44Worker/utils/isContiguousPath.js
+++ b/src/plugins/Workers/BIP44Worker/utils/isContiguousPath.js
@@ -1,0 +1,15 @@
+const is = require('../../../../utils/is');
+
+module.exports = function isContiguousPath(currPath, prevPath) {
+  if (is.undef(currPath)) return false;
+
+  const splitedCurrPath = currPath.split('/');
+  const currIndex = parseInt(splitedCurrPath[5], 10);
+
+  if (is.undef(prevPath)) {
+    return currIndex === 0;
+  }
+  const splitedPrevPath = prevPath.split('/');
+  const prevIndex = parseInt(splitedPrevPath[5], 10);
+  return prevIndex === currIndex - 1;
+};

--- a/src/types/Storage/methods/importTransaction.js
+++ b/src/types/Storage/methods/importTransaction.js
@@ -14,6 +14,7 @@ const importTransaction = function importTransaction(transaction) {
 
   let hasUpdateStorage = false;
   let outputIndex = -1;
+  const processedAddressesForTx = [];
 
   // If we already had this transaction locally, we won't add it again,
   // but we still need to continue processing it as we might have new
@@ -22,7 +23,7 @@ const importTransaction = function importTransaction(transaction) {
     transactions[transaction.hash] = transaction;
   }
 
-  [...inputs, ...outputs].forEach((element) => {
+  [...inputs, ...outputs].forEach((element, elementIndex) => {
     const isOutput = (element instanceof Output);
     if (isOutput) outputIndex += 1;
 
@@ -34,27 +35,39 @@ const importTransaction = function importTransaction(transaction) {
         const addressObject = store.wallets[walletId].addresses[type][path];
         if (!addressObject.used) addressObject.used = true;
 
-        if (!addressObject.transactions.includes(transaction.hash)) {
+        if (elementIndex === 0) {
+          // If the transactions has already been processed in a previous insertion,
+          // we can skip the processing now
+          if (addressObject.transactions.includes(transaction.hash)) {
+            // We mark it as already processed
+            processedAddressesForTx.push(addressObject.address);
+            return;
+          }
           addressObject.transactions.push(transaction.hash);
           hasUpdateStorage = true;
-          if (!isOutput) {
-            const vin = element;
-            const utxoKey = `${vin.prevTxId.toString('hex')}-${vin.outputIndex}`;
-            if (addressObject.utxos[utxoKey]) {
-              const previousOutput = addressObject.utxos[utxoKey];
-              addressObject.balanceSat -= previousOutput.satoshis;
-              delete addressObject.utxos[utxoKey];
-              hasUpdateStorage = true;
-            }
-          } else {
-            const vout = element;
+        }
+        // If mark as already procesed on first run, skipping.
+        if (processedAddressesForTx.includes(addressObject.address)) {
+          return;
+        }
 
-            const utxoKey = `${transaction.hash}-${outputIndex}`;
-            if (!addressObject.utxos[utxoKey]) {
-              addressObject.utxos[utxoKey] = vout;
-              addressObject.balanceSat += vout.satoshis;
-              hasUpdateStorage = true;
-            }
+        if (!isOutput) {
+          const vin = element;
+          const utxoKey = `${vin.prevTxId.toString('hex')}-${vin.outputIndex}`;
+          if (addressObject.utxos[utxoKey]) {
+            const previousOutput = addressObject.utxos[utxoKey];
+            addressObject.balanceSat -= previousOutput.satoshis;
+            delete addressObject.utxos[utxoKey];
+            hasUpdateStorage = true;
+          }
+        } else {
+          const vout = element;
+
+          const utxoKey = `${transaction.hash}-${outputIndex}`;
+          if (!addressObject.utxos[utxoKey]) {
+            addressObject.utxos[utxoKey] = vout;
+            addressObject.balanceSat += vout.satoshis;
+            hasUpdateStorage = true;
           }
         }
       }

--- a/src/types/Storage/methods/importTransaction.js
+++ b/src/types/Storage/methods/importTransaction.js
@@ -15,8 +15,9 @@ const importTransaction = function importTransaction(transaction) {
   let hasUpdateStorage = false;
   let outputIndex = -1;
 
-  // If we already had this transaction locally, we won't add it again, but we still need to continue processing it
-  // as we might have new address generated (on BIP44 wallets) since the first checkup.
+  // If we already had this transaction locally, we won't add it again,
+  // but we still need to continue processing it as we might have new
+  // address generated (on BIP44 wallets) since the first checkup.
   if (!transactions[transaction.hash]) {
     transactions[transaction.hash] = transaction;
   }


### PR DESCRIPTION
## Issue being fixed or feature implemented

When we import a transaction and one of it's constitutive element (input or output) impact and address that we own but are not yet aware of it (because it exceed the BIP44 spec on first run, for instance on an index 21). 
We will submit for insertion again, but we where preventing any processing as we already had it. 
This PR fixes that issue. 

## What was done?
- refactored BIP44.ensureEnoughtAddress so utils are splitted in separate file
- ensure importTransaction re-process a transaction on addresses that are not marked as already having it (address.transactions[])


## How Has This Been Tested?

This specific case (us paying to ourself with a gap of address) were not included in test and will require to add it in our Tests improvement PR coming soon.


## Breaking Changes
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation
