### PR TITLE
fix!: createTransaction should be checking for 'recipient' instead of 'address' in 'txOpts.recipients'

### DIFF
--- a/docs/account/createTransaction.md
+++ b/docs/account/createTransaction.md
@@ -33,7 +33,7 @@ const tx1 = account.createTransaction(txOpts1);
 ```
 
 ```js
-const recipients = [{address:"yereyozxENB9jbhqpbg1coE5c39ExqLSaG", satoshis:10e8},{recipient: "yMN2w8NiwcmY3zvJLeeBxpaExFV1aN23pg", satoshis: 1e8}];
+const recipients = [{recipient:"yereyozxENB9jbhqpbg1coE5c39ExqLSaG", satoshis:10e8},{recipient: "yMN2w8NiwcmY3zvJLeeBxpaExFV1aN23pg", satoshis: 1e8}];
 const change = "yaVrJ5dgELFkYwv6AydDyGPAJQ5kTJXyAN";
 const tx = account.createTransaction({recipients, change});
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -61,7 +61,8 @@ Quick note :
 
 ```js
 const options = {
-  recipient:{address:'yLptqWxjgTxtwKJuLHoGY222NnoeqYuN8h', satoshis:100000}
+  recipient:'yLptqWxjgTxtwKJuLHoGY222NnoeqYuN8h',
+  satoshis:100000
 };
 account
   .createTransaction(options)

--- a/src/types/Account/methods/createTransaction.js
+++ b/src/types/Account/methods/createTransaction.js
@@ -39,7 +39,7 @@ function createTransaction(opts) {
     if (!is.arr(opts.recipients)) throw new Error('Expected recipients to be an array of recipient');
     _.each(opts.recipients, (recipient) => {
       if (_.has(recipient, 'recipient') && _.has(recipient, 'satoshis')) {
-        outputs.push(recipient);
+        outputs.push({ address: recipient.recipient, satoshis: recipient.satoshis });
       } else {
         throw new Error(`Invalid recipient provided ${recipient}`);
       }

--- a/src/types/Account/methods/createTransaction.js
+++ b/src/types/Account/methods/createTransaction.js
@@ -38,7 +38,7 @@ function createTransaction(opts) {
   if (_.has(opts, 'recipients')) {
     if (!is.arr(opts.recipients)) throw new Error('Expected recipients to be an array of recipient');
     _.each(opts.recipients, (recipient) => {
-      if (_.has(recipient, 'address') && _.has(recipient, 'satoshis')) {
+      if (_.has(recipient, 'recipient') && _.has(recipient, 'satoshis')) {
         outputs.push(recipient);
       } else {
         throw new Error(`Invalid recipient provided ${recipient}`);

--- a/src/types/Account/methods/createTransaction.spec.js
+++ b/src/types/Account/methods/createTransaction.spec.js
@@ -86,34 +86,34 @@ describe('Account - createTransaction', function suite() {
     const tx2 = await createTransaction.call(mockWallet, {
       recipients: [
         {
-          address: 'yMGXHsi8gstbd5wqfqkqcfsbwJjGBt5sWu',
+          recipient: 'yMGXHsi8gstbd5wqfqkqcfsbwJjGBt5sWu',
           satoshis: 90000000
         }, {
-          address: 'yLeqoVqqGf4hFDwsiJwKiLPpeJbZHJpwo7',
+          recipient: 'yLeqoVqqGf4hFDwsiJwKiLPpeJbZHJpwo7',
           satoshis: 90000000
         }, {
-          address: 'yWCxg5NdRXDagFokjwdLMYNDqfEKmLPtua',
+          recipient: 'yWCxg5NdRXDagFokjwdLMYNDqfEKmLPtua',
           satoshis: 90000000
         }, {
-          address: 'ySPghvb9M1PqjhRYKv7iivQEuebM2aXs9f',
+          recipient: 'ySPghvb9M1PqjhRYKv7iivQEuebM2aXs9f',
           satoshis: 90000000
         }, {
-          address: 'yR8bXVFZAM1ysc8s4GfVTirNhTEzKizY19',
+          recipient: 'yR8bXVFZAM1ysc8s4GfVTirNhTEzKizY19',
           satoshis: 90000000
         }, {
-          address: 'yhoCPK6WyqtB5GmZjVqxy3faR5JMUKbt8x',
+          recipient: 'yhoCPK6WyqtB5GmZjVqxy3faR5JMUKbt8x',
           satoshis: 90000000
         }, {
-          address: 'yTJbGkT7TYVY4MYbTgdSDdq19A3VmjyEUo',
+          recipient: 'yTJbGkT7TYVY4MYbTgdSDdq19A3VmjyEUo',
           satoshis: 90000000
         }, {
-          address: 'yNtvF5g6qnbRsUJ8ggap3pd53HEmkngEJu',
+          recipient: 'yNtvF5g6qnbRsUJ8ggap3pd53HEmkngEJu',
           satoshis: 90000000
         }, {
-          address: 'yia3dGyRdh7xZLDtum1rdCLRqabyBQbcWL',
+          recipient: 'yia3dGyRdh7xZLDtum1rdCLRqabyBQbcWL',
           satoshis: 90000000
         }, {
-          address: 'yXbuPCJagq4XH85hgxqsNv92kSUFroTWUA',
+          recipient: 'yXbuPCJagq4XH85hgxqsNv92kSUFroTWUA',
           satoshis: 90000000
         },
       ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
From PR #148. 

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes

- #145: createTransaction should be checking for `recipient` instead of `address` in `txOpts.recipients`

## What was done?
<!--- Describe your changes in detail -->

Changed checking property of 
`txOpts.recipients | Array[{address, satoshis}]` 
to
`txOpts.recipients | Array[{recipient, satoshis}]`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by creating a valid transaction according to the documented `txOpts` via https://dashevo.github.io/wallet-lib/#/account/createTransaction

```
    const transaction = account.createTransaction({
        recipients: [
          {recipient:'yT4FyAtrkpgnHviyMHe8NnbrVeH1EFVHFM',satoshis:10000}
        ]
    });
```

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

Previously, the documentation stated a usage on createTransaction() with multiples recipients as such: recipients:[{recipient,satoshis}].
However the code where still referring and expecting recipients recipients:[{address,satoshis}].
This PR fixes that inconsistency.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
