### PR TITLE
chore(release): v7.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **Breaking changes:**   
     * Previously, the documentation stated a usage on `createTransaction()` with multiples recipients as such: `recipients:[{recipient,satoshis}]`.   
-    However the code where still refering and expecting recipients `recipients:[{address,satoshis}]`.  
+    However, the code where still referring and expecting recipients `recipients:[{address,satoshis}]`.  
     This version fixes that inconsistency. 
      
 # [7.13.2](https://github.com/dashevo/wallet-lib/compare/v7.13.1...v7.13.2) (2020-06-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [7.13.3](https://github.com/dashevo/wallet-lib/compare/v7.13.2...v7.13.3) (2020-06-16)
+
+- **Fixes:**
+    * fix:createTransaction should be checking for 'recipient' instead of 'address' in 'txOpts.recipients' ([#152](https://github.com/dashevo/wallet-lib/pull/152))
+    * fix: transaction hash not present on address ([#151](https://github.com/dashevo/wallet-lib/pull/151))
+
 # [7.13.2](https://github.com/dashevo/wallet-lib/compare/v7.13.1...v7.13.2) (2020-06-15)
 
 - **Features:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # [7.13.3](https://github.com/dashevo/wallet-lib/compare/v7.13.2...v7.13.3) (2020-06-16)
 
-- **Fixes:**
-    * fix:createTransaction should be checking for 'recipient' instead of 'address' in 'txOpts.recipients' ([#152](https://github.com/dashevo/wallet-lib/pull/152))
+- **Fixes:**  
+    * fix!: createTransaction should be checking for 'recipient' instead of 'address' in 'txOpts.recipients' ([#152](https://github.com/dashevo/wallet-lib/pull/152))
     * fix: transaction hash not present on address ([#151](https://github.com/dashevo/wallet-lib/pull/151))
 
+- **Breaking changes:**   
+    * Previously, the documentation stated a usage on `createTransaction()` with multiples recipients as such: `recipients:[{recipient,satoshis}]`.   
+    However the code where still refering and expecting recipients `recipients:[{address,satoshis}]`.  
+    This version fixes that inconsistency. 
+     
 # [7.13.2](https://github.com/dashevo/wallet-lib/compare/v7.13.1...v7.13.2) (2020-06-15)
 
 - **Features:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "7.13.2",
+  "version": "7.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "7.13.2",
+  "version": "7.13.3",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "unpkg": "dist/wallet-lib.min.js",


### PR DESCRIPTION
# [7.13.3](https://github.com/dashevo/wallet-lib/compare/v7.13.2...v7.13.3) (2020-06-16)

**Notable Changes:**

- **Fixes:**  
    * fix!: createTransaction should be checking for 'recipient' instead of 'address' in 'txOpts.recipients' ([#152](https://github.com/dashevo/wallet-lib/pull/152))
    * fix: transaction hash not present on address ([#151](https://github.com/dashevo/wallet-lib/pull/151))

- **Breaking changes:**   
    * Previously, the documentation stated a usage on `createTransaction()` with multiples recipients as such: `recipients:[{recipient,satoshis}]`.   
    However, the code where still referring and expecting recipients `recipients:[{address,satoshis}]`.  
    This version fixes that inconsistency. 

