### PR TITLE
fix(Account): forward all storage events

### DIFF
--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -84,9 +84,16 @@ class Account extends EventEmitter {
     this.storage = wallet.storage;
 
     // Forward all storage event
-    this.storage.on('**', (ev) => {
-      this.emit(ev.type, ev);
-    });
+    this.storage.on(EVENTS.CONFIGURED, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.REHYDRATE_STATE_FAILED, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.REHYDRATE_STATE_SUCCESS, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.FETCHED_CONFIRMED_TRANSACTION, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.UNCONFIRMED_BALANCE_CHANGED, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.CONFIRMED_BALANCE_CHANGED, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.BLOCKHEADER, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.BLOCKHEIGHT_CHANGED, (ev) => this.emit(ev.type, ev));
+    this.storage.on(EVENTS.BLOCK, (ev) => this.emit(ev.type, ev));
+
     if (this.debug) {
       this.emit = (...args) => {
         const { type } = args[1];

--- a/src/types/Account/Account.spec.js
+++ b/src/types/Account/Account.spec.js
@@ -4,9 +4,18 @@ const knifeMnemonic = require('../../../fixtures/knifeeasily');
 const fluidMnemonic = require('../../../fixtures/fluidDepth');
 const cR4t6ePrivateKey = require('../../../fixtures/cR4t6e_pk');
 const { WALLET_TYPES } = require('../../CONSTANTS');
-const { Account } = require('../../index');
+const { Account, EVENTS } = require('../../index');
+const EventEmitter = require('events');
 const inMem = require('../../adapters/InMem');
-
+const blockHeader = new Dashcore.BlockHeader.fromObject({
+  hash: '00000ac3a0c9df709260e41290d6902e5a4a073099f11fe8c1ce80aadc4bb331',
+  version: 2,
+  prevHash: '00000ce430de949c85a145b02e33ebbaed3772dc8f3d668f66edc6852c24d002',
+  merkleRoot: '663360403b5fba9cd8744c3706f9660c7d3fee4e5a9ee98ce0ad5e5ad7824c1d',
+  time: 1398712821,
+  bits: 504365040,
+  nonce: 312363
+});
 const mocks = {
   adapter: inMem,
   offlineMode: true,
@@ -16,18 +25,23 @@ const mocks = {
 describe('Account - class', function suite() {
   this.timeout(10000);
   before(() => {
+    const emitter = new EventEmitter();
+    const mockStorage = {
+      on: emitter.on,
+      emit: emitter.emit,
+      store: {},
+      getStore: () => {},
+      saveState: () => {},
+      stopWorker: () => {},
+      importBlockHeader: (blockheader)=>{
+        mockStorage.emit(EVENTS.BLOCKHEADER, {type: EVENTS.BLOCKHEADER, payload:blockheader});
+      }
+    };
     mocks.wallet = (new (function Wallet() {
       this.walletId = '1234567891';
       this.accounts = [];
       this.network = Dashcore.Networks.testnet;
-      this.storage = {
-        on: () => {},
-        emit: () => {},
-        store: {},
-        getStore: () => {},
-        saveState: () => {},
-        stopWorker: () => {},
-      };
+      this.storage = mockStorage;
     })());
   });
   it('should be specify on missing params', () => {
@@ -72,5 +86,16 @@ describe('Account - class', function suite() {
     account.disconnect();
     account2.disconnect();
     account3.disconnect();
+  });
+  it('should forward events', function (done) {
+    const mockWallet = mocks.wallet;
+    const account = new Account(mockWallet, { injectDefaultPlugins: false });
+    account.init(mockWallet).then(async ()=>{
+      await account.on(EVENTS.BLOCKHEADER, ()=>{
+        done();
+      });
+      account.storage.importBlockHeader(blockHeader);
+    })
+
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
With a previous PR (https://github.com/dashevo/wallet-lib/pull/137) we removed eventemitter2, we used it's feature to broadcast all events in Account.js. 
We fixed an issue were the event were not forwarded.
Fixes https://github.com/dashevo/DashJS/issues/93.

## What was done?
- manually forward all events emitted by Storage.


## How Has This Been Tested?
- Added a test that ensure Account do forward event from storage using mocked Storage and single event (Blockheader)


## Breaking Changes
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
