### PR TITLE
fix: create transaction recipient documentation

### DIFF
--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -99,11 +99,11 @@ export declare namespace Account {
 
     interface createTransactionOptions {
         recipient?: PublicAddress,
-        satohis?: number,
+        satoshis?: number,
         amount?: number,
 
         recipients?: [RecipientOptions]
-        
+
         change?: string;
         utxos?: [object];
         isInstantSend?: boolean;

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -98,8 +98,12 @@ export declare namespace Account {
     }
 
     interface createTransactionOptions {
-        recipient?: RecipientOptions,
+        recipient?: PublicAddress,
+        satohis?: number,
+        amount?: number,
+
         recipients?: [RecipientOptions]
+        
         change?: string;
         utxos?: [object];
         isInstantSend?: boolean;


### PR DESCRIPTION
## Issue being fixed or feature implemented

When creating a transaction with a unique recipient, two parameters will need to be passed : 
- recipient, a PublicAddress
- satoshis or amount, a number. 

In our documentation we were referring to Recipient as a single object having an address, satoshis/amount.

This PR fixes that documentation issue.

## What was done?
- modified Account.d.ts to refer to the correct usage
- verified /docs/Account/createTransaction correctness

## How Has This Been Tested?
No code change.


## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
