### PR TITLE
fix: confirmation might come before broadcast ACK

### DIFF
--- a/src/utils/fundWallet.js
+++ b/src/utils/fundWallet.js
@@ -38,9 +38,10 @@ async function fundWallet(faucetWallet, recipientWallet, amount) {
     recipient: recipientAccount.getAddress().address,
   });
 
-  await faucetAccount.broadcastTransaction(transaction);
-
-  await waitForTransaction(recipientAccount, transaction.id);
+  await Promise.all([
+    faucetAccount.broadcastTransaction(transaction),
+    waitForTransaction(recipientAccount, transaction.id),
+  ]);
 
   return transaction.id;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Transaction confirmation might come before broadcast ACK in the `fundWallet` function

## What was done?
<!--- Describe your changes in detail -->
`waitForTransaction` calls immediately after broadcast without getting ACK 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
