### PR TITLE
feat: workers and plugins error handling using events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 install:
   - npm ci

--- a/src/plugins/StandardPlugin.js
+++ b/src/plugins/StandardPlugin.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const EventEmitter = require('events');
-const { InjectionToPluginUnallowed, PluginFailedOnStart } = require('../errors');
+const { InjectionToPluginUnallowed } = require('../errors');
 const { SAFE_FUNCTIONS, SAFE_PROPERTIES } = require('../CONSTANTS').INJECTION_LISTS;
 
 const defaultOpts = {
@@ -36,7 +36,7 @@ class StandardPlugin extends EventEmitter {
       const eventType = `PLUGIN/${this.name.toUpperCase()}/STARTED`;
       self.parentEvents.emit(eventType, { type: eventType, payload: null });
     } catch (e) {
-      throw new PluginFailedOnStart(this.pluginType, this.name, e);
+      this.emit('error', e);
     }
   }
 
@@ -45,7 +45,7 @@ class StandardPlugin extends EventEmitter {
     if (SAFE_FUNCTIONS.includes(name) || SAFE_PROPERTIES.includes(name)) {
       this[name] = obj;
     } else if (PLUGINS_NAME_LIST.includes(name)) {
-      throw new Error('Inter-plugin support yet to come');
+      this.emit('error', new Error('Inter-plugin support yet to come'));
     } else if (allowSensitiveOperations === true) {
       this[name] = obj;
     } else if (name === 'parentEvents') {
@@ -54,7 +54,7 @@ class StandardPlugin extends EventEmitter {
       // this.parentEvents = {on:obj.on, emit:obj.emit};
       this.parentEvents = obj;
     } else {
-      throw new InjectionToPluginUnallowed(name);
+      this.emit('error', new InjectionToPluginUnallowed(name));
     }
     return true;
   }

--- a/src/plugins/StandardPlugin.js
+++ b/src/plugins/StandardPlugin.js
@@ -36,7 +36,11 @@ class StandardPlugin extends EventEmitter {
       const eventType = `PLUGIN/${this.name.toUpperCase()}/STARTED`;
       self.parentEvents.emit(eventType, { type: eventType, payload: null });
     } catch (e) {
-      this.emit('error', e);
+      this.emit('error', e, {
+        type: 'plugin',
+        pluginType: 'plugin',
+        pluginName: this.name,
+      });
     }
   }
 
@@ -45,7 +49,11 @@ class StandardPlugin extends EventEmitter {
     if (SAFE_FUNCTIONS.includes(name) || SAFE_PROPERTIES.includes(name)) {
       this[name] = obj;
     } else if (PLUGINS_NAME_LIST.includes(name)) {
-      this.emit('error', new Error('Inter-plugin support yet to come'));
+      this.emit('error', new Error('Inter-plugin support yet to come'), {
+        type: 'plugin',
+        pluginType: 'plugin',
+        pluginName: this.name,
+      });
     } else if (allowSensitiveOperations === true) {
       this[name] = obj;
     } else if (name === 'parentEvents') {
@@ -54,7 +62,11 @@ class StandardPlugin extends EventEmitter {
       // this.parentEvents = {on:obj.on, emit:obj.emit};
       this.parentEvents = obj;
     } else {
-      this.emit('error', new InjectionToPluginUnallowed(name));
+      this.emit('error', new InjectionToPluginUnallowed(name), {
+        type: 'plugin',
+        pluginType: 'plugin',
+        pluginName: this.name,
+      });
     }
     return true;
   }

--- a/src/plugins/Worker.js
+++ b/src/plugins/Worker.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const logger = require('../logger');
 const StandardPlugin = require('./StandardPlugin');
-const { WorkerFailedOnExecute, WorkerFailedOnStart } = require('../errors');
 
 // eslint-disable-next-line no-underscore-dangle
 const _defaultOpts = {
@@ -66,7 +65,7 @@ class Worker extends StandardPlugin {
 
       if (this.executeOnStart) await this.execWorker();
     } catch (e) {
-      throw new WorkerFailedOnStart(this.name, e);
+      this.emit('error', e);
     }
   }
 
@@ -101,8 +100,7 @@ class Worker extends StandardPlugin {
         payloadResult = await this.execute();
       } catch (e) {
         await this.stopWorker(e.message);
-
-        throw new WorkerFailedOnExecute(this.name, e);
+        this.emit('error', e);
       }
     } else {
       throw new Error(`Worker ${this.name}: Missing execute function`);

--- a/src/plugins/Worker.js
+++ b/src/plugins/Worker.js
@@ -65,7 +65,11 @@ class Worker extends StandardPlugin {
 
       if (this.executeOnStart) await this.execWorker();
     } catch (e) {
-      this.emit('error', e);
+      this.emit('error', e, {
+        type: 'plugin',
+        pluginType: 'worker',
+        pluginName: this.name,
+      });
     }
   }
 
@@ -100,7 +104,11 @@ class Worker extends StandardPlugin {
         payloadResult = await this.execute();
       } catch (e) {
         await this.stopWorker(e.message);
-        this.emit('error', e);
+        this.emit('error', e, {
+          type: 'plugin',
+          pluginType: 'worker',
+          pluginName: this.name,
+        });
       }
     } else {
       throw new Error(`Worker ${this.name}: Missing execute function`);

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/startHistoricalSync.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/startHistoricalSync.js
@@ -53,7 +53,7 @@ module.exports = async function startHistoricalSync(network) {
     }
 
     this.stream = null;
-    throw e;
+    this.emit('error', e);
   }
 
   this.setLastSyncedBlockHeight(bestBlockHeight);

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/startHistoricalSync.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/startHistoricalSync.js
@@ -53,7 +53,11 @@ module.exports = async function startHistoricalSync(network) {
     }
 
     this.stream = null;
-    this.emit('error', e);
+    this.emit('error', e, {
+      type: 'plugin',
+      pluginType: 'worker',
+      pluginName: this.name,
+    });
   }
 
   this.setLastSyncedBlockHeight(bestBlockHeight);

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/startIncomingSync.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/startIncomingSync.js
@@ -46,6 +46,6 @@ module.exports = async function startIncomingSync() {
       return;
     }
 
-    throw e;
+    this.emit('error', e);
   }
 };

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/startIncomingSync.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/startIncomingSync.js
@@ -46,6 +46,10 @@ module.exports = async function startIncomingSync() {
       return;
     }
 
-    this.emit('error', e);
+    this.emit('error', e, {
+      type: 'plugin',
+      pluginType: 'worker',
+      pluginName: this.name,
+    });
   }
 };

--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -75,6 +75,13 @@ class Account extends EventEmitter {
 
     this.label = (opts && opts.label && is.string(opts.label)) ? opts.label : null;
 
+    // Forward async error events to wallet allowing catching during initial sync
+    this.on('error', (error) => wallet.emit('error', error, {
+      accountIndex: this.index,
+      network: this.network,
+      label: this.label,
+    }));
+
     // If transport is null or invalid, we won't try to fetch anything
     this.transport = wallet.transport;
 

--- a/src/types/Account/Account.js
+++ b/src/types/Account/Account.js
@@ -76,7 +76,8 @@ class Account extends EventEmitter {
     this.label = (opts && opts.label && is.string(opts.label)) ? opts.label : null;
 
     // Forward async error events to wallet allowing catching during initial sync
-    this.on('error', (error) => wallet.emit('error', error, {
+    this.on('error', (error, errorContext) => wallet.emit('error', error, {
+      ...errorContext,
       accountIndex: this.index,
       network: this.network,
       label: this.label,

--- a/src/types/Account/_initializeAccount.js
+++ b/src/types/Account/_initializeAccount.js
@@ -23,14 +23,14 @@ async function _initializeAccount(account, userUnsafePlugins) {
   // TODO: perform rejection with a timeout
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
-    if (account.injectDefaultPlugins) {
+    try {
+      if (account.injectDefaultPlugins) {
       // TODO: Should check in other accounts if a similar is setup already
       // TODO: We want to sort them by dependencies and deal with the await this way
       // await parent if child has it in dependency
       // if not, then is it marked as requiring a first exec
       // if yes add to watcher list.
 
-      try {
         if ([WALLET_TYPES.HDWALLET, WALLET_TYPES.HDPUBLIC].includes(account.walletType)) {
           ensureAddressesToGapLimit(
             account.store.wallets[account.walletId],
@@ -53,86 +53,76 @@ async function _initializeAccount(account, userUnsafePlugins) {
             await account.injectPlugin(IdentitySyncWorker, true);
           }
         }
-      } catch (e) {
-        reject(new PluginInjectionError(e));
       }
-    }
 
-    _.each(userUnsafePlugins, (UnsafePlugin) => {
-      account.injectPlugin(UnsafePlugin, account.allowSensitiveOperations)
-        .catch((e) => {
-          if (![
-            PluginFailedOnStart,
-            WorkerFailedOnExecute,
-            InjectionToPluginUnallowed,
-          ].includes(e.constructor)) {
-            reject(new Error(`Failed to inject plugin: ${UnsafePlugin.name}, reason: ${e.message}`));
-          }
-          return reject(e);
-        });
-    });
-
-    self.emit(EVENTS.STARTED, { type: EVENTS.STARTED, payload: null });
-
-    const sendReady = () => {
-      if (!self.state.isReady) {
-        self.emit(EVENTS.READY, { type: EVENTS.READY, payload: null });
-        self.state.isReady = true;
-      }
-    };
-    const sendInitialized = () => {
-      if (!self.state.isInitialized) {
-        self.emit(EVENTS.INITIALIZED, { type: EVENTS.INITIALIZED, payload: null });
-        logger.debug(`Initialized with ${Object.keys(account.plugins.watchers).length} plugins`);
-        self.state.isInitialized = true;
-      }
-    };
-
-    // eslint-disable-next-line no-param-reassign,consistent-return
-    account.readinessInterval = setInterval(() => {
-      const watchedPlugins = Object.keys(account.plugins.watchers);
-      let readyPlugins = 0;
-      watchedPlugins.forEach((pluginName) => {
-        if (account.plugins.watchers[pluginName].ready === true) {
-          logger.debug(`Initializing - ${readyPlugins}/${watchedPlugins.length} plugins`);
-          readyPlugins += 1;
-          logger.debug(`Initialized ${pluginName} - ${readyPlugins}/${watchedPlugins.length} plugins`);
-        }
+      _.each(userUnsafePlugins, (UnsafePlugin) => {
+        account.injectPlugin(UnsafePlugin, account.allowSensitiveOperations);
       });
-      logger.debug(`Initializing - ${readyPlugins}/${watchedPlugins.length} plugins`);
-      if (readyPlugins === watchedPlugins.length) {
+
+      self.emit(EVENTS.STARTED, { type: EVENTS.STARTED, payload: null });
+
+      const sendReady = () => {
+        if (!self.state.isReady) {
+          self.emit(EVENTS.READY, { type: EVENTS.READY, payload: null });
+          self.state.isReady = true;
+        }
+      };
+      const sendInitialized = () => {
+        if (!self.state.isInitialized) {
+          self.emit(EVENTS.INITIALIZED, { type: EVENTS.INITIALIZED, payload: null });
+          logger.debug(`Initialized with ${Object.keys(account.plugins.watchers).length} plugins`);
+          self.state.isInitialized = true;
+        }
+      };
+
+      // eslint-disable-next-line no-param-reassign,consistent-return
+      account.readinessInterval = setInterval(() => {
+        const watchedPlugins = Object.keys(account.plugins.watchers);
+        let readyPlugins = 0;
+        watchedPlugins.forEach((pluginName) => {
+          if (account.plugins.watchers[pluginName].ready === true) {
+            logger.debug(`Initializing - ${readyPlugins}/${watchedPlugins.length} plugins`);
+            readyPlugins += 1;
+            logger.debug(`Initialized ${pluginName} - ${readyPlugins}/${watchedPlugins.length} plugins`);
+          }
+        });
+        logger.debug(`Initializing - ${readyPlugins}/${watchedPlugins.length} plugins`);
+        if (readyPlugins === watchedPlugins.length) {
         // At this stage, our worker are initialized
-        sendInitialized();
+          sendInitialized();
 
-        // If both of the plugins are present
-        // We need to tweak it a little bit to have BIP44 ensuring address
-        // while SyncWorker fetch'em on network
-        clearInterval(self.readinessInterval);
+          // If both of the plugins are present
+          // We need to tweak it a little bit to have BIP44 ensuring address
+          // while SyncWorker fetch'em on network
+          clearInterval(self.readinessInterval);
 
-        if (account.walletType === WALLET_TYPES.SINGLE_ADDRESS) {
-          account.generateAddress(0);
+          if (account.walletType === WALLET_TYPES.SINGLE_ADDRESS) {
+            account.generateAddress(0);
+            sendReady();
+            return resolve(true);
+          }
+
+          if (!account.injectDefaultPlugins) {
+            sendReady();
+            return resolve(true);
+          }
+
+          if ([WALLET_TYPES.HDWALLET, WALLET_TYPES.HDPUBLIC].includes(account.walletType)) {
+            ensureAddressesToGapLimit(
+              account.store.wallets[account.walletId],
+              account.walletType,
+              account.index,
+              account.getAddress.bind(account),
+            );
+          }
+
           sendReady();
           return resolve(true);
         }
-
-        if (!account.injectDefaultPlugins) {
-          sendReady();
-          return resolve(true);
-        }
-
-        if ([WALLET_TYPES.HDWALLET, WALLET_TYPES.HDPUBLIC].includes(account.walletType)) {
-          ensureAddressesToGapLimit(
-            account.store.wallets[account.walletId],
-            account.walletType,
-            account.index,
-            account.getAddress.bind(account),
-          );
-        }
-
-        sendReady();
-        return resolve(true);
-      }
-    }, readinessIntervalTime);
+      }, readinessIntervalTime);
+    } catch (e) {
+      reject(e);
+    }
   });
 }
 

--- a/src/types/Account/_initializeAccount.js
+++ b/src/types/Account/_initializeAccount.js
@@ -6,13 +6,6 @@ const IdentitySyncWorker = require('../../plugins/Workers/IdentitySyncWorker');
 const EVENTS = require('../../EVENTS');
 const { WALLET_TYPES } = require('../../CONSTANTS');
 
-const {
-  PluginFailedOnStart,
-  WorkerFailedOnExecute,
-  InjectionToPluginUnallowed,
-  PluginInjectionError,
-} = require('../../errors');
-
 const ensureAddressesToGapLimit = require('../../utils/bip44/ensureAddressesToGapLimit');
 
 // eslint-disable-next-line no-underscore-dangle

--- a/src/types/Account/methods/injectPlugin.js
+++ b/src/types/Account/methods/injectPlugin.js
@@ -25,7 +25,7 @@ module.exports = async function injectPlugin(
     try {
       const isInit = !(typeof UnsafePlugin === 'function');
       const plugin = (isInit) ? UnsafePlugin : new UnsafePlugin();
-      plugin.on('error', (e) => self.emit('error', e));
+      plugin.on('error', (e, errContext) => self.emit('error', e, errContext));
 
       const pluginName = plugin.name.toLowerCase();
       logger.debug(`Account.injectPlugin(${pluginName}) - starting injection`);

--- a/src/types/Account/methods/injectPlugin.js
+++ b/src/types/Account/methods/injectPlugin.js
@@ -25,6 +25,7 @@ module.exports = async function injectPlugin(
     try {
       const isInit = !(typeof UnsafePlugin === 'function');
       const plugin = (isInit) ? UnsafePlugin : new UnsafePlugin();
+      plugin.on('error', (e) => self.emit('error', e));
 
       const pluginName = plugin.name.toLowerCase();
       logger.debug(`Account.injectPlugin(${pluginName}) - starting injection`);

--- a/src/types/Account/methods/injectPlugin.spec.js
+++ b/src/types/Account/methods/injectPlugin.spec.js
@@ -40,7 +40,7 @@ describe('Account - injectPlugin', function suite() {
     }, 10000);
   });
   it('should handle faulty worker', async function () {
-    const expectedException1 = 'Worker FaultyWorker failed onStart: Worker FaultyWorker failed onExecute: Some reason.';
+    const expectedException1 = 'Some reason.';
     await expectThrowsAsync(async () => await injectPlugin.call(mockedSelf, FaultyWorker, true), expectedException1);
       expect(mockedSelf.plugins.workers['faultyworker']).to.exist;
       expect(mockedSelf.plugins.workers['faultyworker'].worker).to.equal(null);

--- a/src/types/Wallet/Wallet.js
+++ b/src/types/Wallet/Wallet.js
@@ -1,5 +1,6 @@
 const { PrivateKey, Networks } = require('@dashevo/dashcore-lib');
 
+const EventEmitter = require('events');
 const _ = require('lodash');
 const Storage = require('../Storage/Storage');
 const {
@@ -38,12 +39,13 @@ const createTransportFromOptions = require('../../transport/createTransportFromO
  *     - address : opts.privateKey is provided. Allow to handle a single address object.
  *     - hdwallet : opts.mnemonic or opts.seed is provided. Handle a HD Wallet with it's account.
  */
-class Wallet {
+class Wallet extends EventEmitter {
   /**
    *
    * @param opts
    */
   constructor(opts = defaultOptions) {
+    super();
     // Immediate prototype method-composition are used in order to give access in constructor.
     Object.assign(Wallet.prototype, {
       fromMnemonic,


### PR DESCRIPTION
## Issue being fixed or feature implemented

In order to provide a better way to debug and handle errors that would be thrown on plugins, we need to provide more control and management of them.


## What was done?

- Wallet is now extending EventEmitter
- Account forwards errors to Wallet with arg 1 being the error and arg 2 referencing label, network and index of the account
- Plugin do not wrap errors but instead emit directly to Account their error conserving the stacktrace of the error


## How Has This Been Tested?
N/A


## Breaking Changes
- Invalidate many of the previous wrapped errors (PluginFailedOnStart, ...)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
