### PR TITLE
fix: UTXO being mixed up with multiple account in parallel

### DIFF
--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.js
@@ -1,23 +1,15 @@
 const { WALLET_TYPES } = require('../../../../CONSTANTS');
 
 module.exports = function getAddressesToSync() {
-  const addressList = [];
-  const { addresses } = this.storage.getStore().wallets[this.walletId];
-  // addressType being external, internal or misc
-  Object.keys(addresses).forEach((addressType) => {
-    // if walletType === BIP44, then not only path that match can be added
-    const accountAddresses = addresses[addressType];
-    let accountPaths = Object.keys(accountAddresses);
-    // Separate between address of account 0 and another account
-    if ([WALLET_TYPES.HDPUBLIC, WALLET_TYPES.HDWALLET].includes(this.walletType)) {
-      accountPaths = accountPaths.filter((path) => path.startsWith(this.BIP44PATH));
-    }
-    if (accountPaths.length > 0) {
-      accountPaths.forEach((path) => {
-        const { address } = accountAddresses[path];
-        addressList.push(address);
-      });
-    }
-  });
-  return addressList;
+  const { BIP44PATH, walletId, walletType } = this;
+  const { addresses } = this.storage.getStore().wallets[walletId];
+
+  const isHDWallet = [WALLET_TYPES.HDPUBLIC, WALLET_TYPES.HDWALLET].includes(walletType);
+  // We have two cases, for privateKey based wallet, we return all address in store.
+  // But for HDWallet, addresses in store can be of another account, that we filter out
+  return Object.keys(addresses)
+    .map((addressType) => Object.values(addresses[addressType]))
+    .flatMap((addressList) => addressList)
+    .filter((accountAddress) => !isHDWallet || accountAddress.path.startsWith(BIP44PATH))
+    .map((filteredAccountAddress) => filteredAccountAddress.address);
 };

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.js
@@ -1,13 +1,20 @@
+const { WALLET_TYPES } = require('../../../../CONSTANTS');
+
 module.exports = function getAddressesToSync() {
   const addressList = [];
-
   const { addresses } = this.storage.getStore().wallets[this.walletId];
-  Object.keys(addresses).forEach((walletType) => {
-    const walletAddresses = addresses[walletType];
-    const walletPaths = Object.keys(walletAddresses);
-    if (walletPaths.length > 0) {
-      walletPaths.forEach((path) => {
-        const { address } = walletAddresses[path];
+  // addressType being external, internal or misc
+  Object.keys(addresses).forEach((addressType) => {
+    // if walletType === BIP44, then not only path that match can be added
+    const accountAddresses = addresses[addressType];
+    let accountPaths = Object.keys(accountAddresses);
+    // Separate between address of account 0 and another account
+    if ([WALLET_TYPES.HDPUBLIC, WALLET_TYPES.HDWALLET].includes(this.walletType)) {
+      accountPaths = accountPaths.filter((path) => path.startsWith(this.BIP44PATH));
+    }
+    if (accountPaths.length > 0) {
+      accountPaths.forEach((path) => {
+        const { address } = accountAddresses[path];
         addressList.push(address);
       });
     }

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.spec.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.spec.js
@@ -1,6 +1,27 @@
 const { expect } = require('chai');
 const getAddressesToSync = require('./getAddressesToSync');
 
+const mockedStore1 = {
+  wallets: {
+    123456789: {
+      addresses: {
+        misc:{
+          '0':{
+            address: 'yizmJb63ygipuJaRgYtpWCV2erQodmaZt1',
+            balanceSat: 0,
+            fetchedLast: 0,
+            path: "0",
+            transactions: [],
+            index: 0,
+            unconfirmedBalanceSat: 0,
+            used: false,
+            utxos: {}
+          }
+        }
+      },
+    },
+  },
+}
 const mockedStore2 = {
   wallets: {
     123456789: {
@@ -53,27 +74,64 @@ const mockedStore2 = {
             }
           }
         },
+        internal:{
+          "m/44'/1'/0'/1/0": {
+            address: 'yizmJb63ygipuJaRgYtpWCV2erQodmaZt9',
+            balanceSat: 0,
+            fetchedLast: 0,
+            path: "m/44'/1'/0'/1/0",
+            transactions: [],
+            index: 0,
+            unconfirmedBalanceSat: 0,
+            used: false,
+            utxos: {}
+          }
+        },
+        misc:{
+          '0':{
+            address: 'yizmJb63ygipuJaRgYtpWCV2erQodmaZt1',
+            balanceSat: 0,
+            fetchedLast: 0,
+            path: "0",
+            transactions: [],
+            index: 0,
+            unconfirmedBalanceSat: 0,
+            used: false,
+            utxos: {}
+          }
+        }
       },
     },
   },
 };
+
+const mockSelfPrivateKeyType = {
+  storage: { getStore:()=>mockedStore1 },
+  walletId: '123456789',
+  walletType: 'single_address',
+}
 const mockSelfIndex0 = {
   storage: { getStore:()=>mockedStore2 },
   walletId: '123456789',
   walletType: 'hdwallet',
-  BIP44PATH: `m/44'/1'/0'/0/0`
+  BIP44PATH: `m/44'/1'/0'`
 }
 const mockSelfIndex1 = {
   ...mockSelfIndex0,
-  BIP44PATH: `m/44'/1'/1'/0/0`
+  BIP44PATH: `m/44'/1'/1'`
 }
+
+
 describe('TransactionSyncStreamWorker#getAddressesToSync', function suite() {
   it('should correctly fetch addresses to sync', async () => {
 
     const addressesIndex0 = getAddressesToSync.call(mockSelfIndex0 );
-    expect(addressesIndex0).to.deep.equal(['yizmJb63ygipuJaRgYtpWCV2erQodmaZt8'])
+    expect(addressesIndex0).to.deep.equal(['yizmJb63ygipuJaRgYtpWCV2erQodmaZt8', 'yizmJb63ygipuJaRgYtpWCV2erQodmaZt9'])
 
     const addressesIndex1 = getAddressesToSync.call(mockSelfIndex1 );
     expect(addressesIndex1).to.deep.equal(['yQ5TfKcj3NHM4V4K5VBgoFJj9Q4LKX13gn'])
+
+    const addressesIndex2 = getAddressesToSync.call(mockSelfPrivateKeyType );
+    expect(addressesIndex2).to.deep.equal(['yizmJb63ygipuJaRgYtpWCV2erQodmaZt1'])
   });
 });

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.spec.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/getAddressesToSync.spec.js
@@ -1,0 +1,79 @@
+const { expect } = require('chai');
+const getAddressesToSync = require('./getAddressesToSync');
+
+const mockedStore2 = {
+  wallets: {
+    123456789: {
+      addresses: {
+        external: {
+          "m/44'/1'/0'/0/0": {
+            address: 'yizmJb63ygipuJaRgYtpWCV2erQodmaZt8',
+            balanceSat: 100000000,
+            fetchedLast: 0,
+            path: "m/44'/1'/0'/0/0",
+            transactions: [
+              'dd7afaadedb5f022cec6e33f1c8520aac897df152bd9f876842f3723ab9614bc',
+              '1d8f924bef2e24d945d7de2ac66e98c8625e4cefeee4e07db2ea334ce17f9c35',
+              '7ae825f4ecccd1e04e6c123e0c55d236c79cd04c6ab64e839aed2ae0af3003e6',
+            ],
+            index: 0,
+            unconfirmedBalanceSat: 0,
+            used: true,
+            utxos: {
+              "dd7afaadedb5f022cec6e33f1c8520aac897df152bd9f876842f3723ab9614bc-0":
+                  {
+                    address: 'yizmJb63ygipuJaRgYtpWCV2erQodmaZt8',
+                    txId: 'dd7afaadedb5f022cec6e33f1c8520aac897df152bd9f876842f3723ab9614bc',
+                    outputIndex: 0,
+                    script: '76a914f8c2652847720ab6d401291e5a48e2c8fe5d3c9f88ac',
+                    satoshis: 100000000,
+                  },
+            }
+          },
+          "m/44'/1'/1'/0/0":{
+            address: 'yQ5TfKcj3NHM4V4K5VBgoFJj9Q4LKX13gn',
+            balanceSat: 14419880000,
+            fetchedLast: 0,
+            path: "m/44'/1'/1'/0/0",
+            transactions: [
+              'b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba',
+            ],
+            index: 0,
+            unconfirmedBalanceSat: 0,
+            used: true,
+            utxos: {
+              "b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba-0":
+                  {
+                    address: 'yQ5TfKcj3NHM4V4K5VBgoFJj9Q4LKX13gn',
+                    txId: 'b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba',
+                    outputIndex: 0,
+                    script: '76a914293b5b9a2154a0e4543027d694276cd5fdcb74cd88ac',
+                    satoshis: 14419880000,
+                  },
+            }
+          }
+        },
+      },
+    },
+  },
+};
+const mockSelfIndex0 = {
+  storage: { getStore:()=>mockedStore2 },
+  walletId: '123456789',
+  walletType: 'hdwallet',
+  BIP44PATH: `m/44'/1'/0'/0/0`
+}
+const mockSelfIndex1 = {
+  ...mockSelfIndex0,
+  BIP44PATH: `m/44'/1'/1'/0/0`
+}
+describe('TransactionSyncStreamWorker#getAddressesToSync', function suite() {
+  it('should correctly fetch addresses to sync', async () => {
+
+    const addressesIndex0 = getAddressesToSync.call(mockSelfIndex0 );
+    expect(addressesIndex0).to.deep.equal(['yizmJb63ygipuJaRgYtpWCV2erQodmaZt8'])
+
+    const addressesIndex1 = getAddressesToSync.call(mockSelfIndex1 );
+    expect(addressesIndex1).to.deep.equal(['yQ5TfKcj3NHM4V4K5VBgoFJj9Q4LKX13gn'])
+  });
+});

--- a/src/types/Account/methods/getUTXOS.js
+++ b/src/types/Account/methods/getUTXOS.js
@@ -1,4 +1,5 @@
 const { Address, Transaction } = require('@dashevo/dashcore-lib');
+const { WALLET_TYPES } = require('../../../CONSTANTS');
 /**
  * Return all the utxos
  * @return {UnspentOutput[]}
@@ -7,15 +8,23 @@ function getUTXOS() {
   const utxos = [];
 
   const self = this;
-  const { walletId, network } = this;
+  const {
+    walletId, network, BIP44PATH, walletType,
+  } = this;
   const currentBlockHeight = this.store.chains[network].blockHeight;
   /* eslint-disable-next-line no-restricted-syntax */
-  for (const walletType in this.store.wallets[walletId].addresses) {
-    if (walletType && ['external', 'internal', 'misc'].includes(walletType)) {
+  for (const addressType in this.store.wallets[walletId].addresses) {
+    if (addressType && ['external', 'internal', 'misc'].includes(addressType)) {
       /* eslint-disable-next-line no-restricted-syntax */
-      for (const path in self.store.wallets[walletId].addresses[walletType]) {
+      for (const path in self.store.wallets[walletId].addresses[addressType]) {
         if (path) {
-          const address = self.store.wallets[walletId].addresses[walletType][path];
+          const address = self.store.wallets[walletId].addresses[addressType][path];
+          if (
+            [WALLET_TYPES.HDPUBLIC, WALLET_TYPES.HDWALLET].includes(walletType)
+              && !path.startsWith(BIP44PATH)) {
+            // eslint-disable-next-line no-continue
+            continue;
+          }
           /* eslint-disable-next-line no-restricted-syntax */
           for (const identifier in address.utxos) {
             if (identifier) {

--- a/src/types/Account/methods/getUTXOS.js
+++ b/src/types/Account/methods/getUTXOS.js
@@ -1,64 +1,63 @@
+/* eslint-disable no-continue, no-restricted-syntax */
 const { Address, Transaction } = require('@dashevo/dashcore-lib');
 const { WALLET_TYPES } = require('../../../CONSTANTS');
+
 /**
  * Return all the utxos
  * @return {UnspentOutput[]}
  */
 function getUTXOS() {
-  const utxos = [];
-
   const self = this;
   const {
-    walletId, network, BIP44PATH, walletType,
+    walletId,
+    network,
+    BIP44PATH,
+    walletType,
   } = this;
+
+  const utxos = [];
+  const isHDWallet = [WALLET_TYPES.HDPUBLIC, WALLET_TYPES.HDWALLET].includes(walletType);
+
   const currentBlockHeight = this.store.chains[network].blockHeight;
-  /* eslint-disable-next-line no-restricted-syntax */
+
   for (const addressType in this.store.wallets[walletId].addresses) {
-    if (addressType && ['external', 'internal', 'misc'].includes(addressType)) {
-      /* eslint-disable-next-line no-restricted-syntax */
-      for (const path in self.store.wallets[walletId].addresses[addressType]) {
-        if (path) {
-          const address = self.store.wallets[walletId].addresses[addressType][path];
-          if (
-            [WALLET_TYPES.HDPUBLIC, WALLET_TYPES.HDWALLET].includes(walletType)
-              && !path.startsWith(BIP44PATH)) {
-            // eslint-disable-next-line no-continue
+    if (!addressType || !['external', 'internal', 'misc'].includes(addressType)) {
+      continue;
+    }
+    for (const path in self.store.wallets[walletId].addresses[addressType]) {
+      if (!path) continue;
+      const address = self.store.wallets[walletId].addresses[addressType][path];
+
+      if (isHDWallet && !path.startsWith(BIP44PATH)) continue;
+
+      for (const identifier in address.utxos) {
+        if (!identifier) continue;
+        const [txid, outputIndex] = identifier.split('-');
+        const transaction = this.store.transactions[txid];
+        if (transaction.isCoinbase()) {
+          // If the transaction is not a special transaction, we can't check its
+          // maturity at the moment of writing this comment.
+          // The wallet library doesn't maintain the header chain and thus we can
+          // figure out the height only from the payload, but old coinbase transactions
+          // doesn't have a payload.
+          if (!transaction.isSpecialTransaction()) {
             continue;
           }
-          /* eslint-disable-next-line no-restricted-syntax */
-          for (const identifier in address.utxos) {
-            if (identifier) {
-              const [txid, outputIndex] = identifier.split('-');
-              const transaction = this.store.transactions[txid];
-              if (transaction.isCoinbase()) {
-                // If the transaction is not a special transaction, we can't check its
-                // maturity at the moment of writing this comment.
-                // The wallet library doesn't maintain the header chain and thus we can
-                // figure out the height only from the payload, but old coinbase transactions
-                // doesn't have a payload.
-                if (!transaction.isSpecialTransaction()) {
-                  // eslint-disable-next-line no-continue
-                  continue;
-                }
-                // We check maturity is at least 100 blocks.
-                // another way is to just read _scriptBuffer height value.
-                if (transaction.extraPayload.height + 100 > currentBlockHeight) {
-                  // eslint-disable-next-line no-continue
-                  continue;
-                }
-              }
-              utxos.push(new Transaction.UnspentOutput(
-                {
-                  txId: txid,
-                  vout: parseInt(outputIndex, 10),
-                  script: address.utxos[identifier].script,
-                  satoshis: address.utxos[identifier].satoshis,
-                  address: new Address(address.address, network),
-                },
-              ));
-            }
+          // We check maturity is at least 100 blocks.
+          // another way is to just read _scriptBuffer height value.
+          if (transaction.extraPayload.height + 100 > currentBlockHeight) {
+            continue;
           }
         }
+        utxos.push(new Transaction.UnspentOutput(
+          {
+            txId: txid,
+            vout: parseInt(outputIndex, 10),
+            script: address.utxos[identifier].script,
+            satoshis: address.utxos[identifier].satoshis,
+            address: new Address(address.address, network),
+          },
+        ));
       }
     }
   }

--- a/src/types/Account/methods/getUTXOS.spec.js
+++ b/src/types/Account/methods/getUTXOS.spec.js
@@ -45,6 +45,28 @@ const mockedStore2 = {
                   },
             }
           },
+          "m/44'/1'/1'/0/0":{
+            address: 'yQ5TfKcj3NHM4V4K5VBgoFJj9Q4LKX13gn',
+            balanceSat: 14419880000,
+            fetchedLast: 0,
+            path: "m/44'/1'/1'/0/0",
+            transactions: [
+              'b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba',
+            ],
+            index: 0,
+            unconfirmedBalanceSat: 0,
+            used: true,
+            utxos: {
+              "b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba-0":
+                  {
+                    address: 'yQ5TfKcj3NHM4V4K5VBgoFJj9Q4LKX13gn',
+                    txId: 'b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba',
+                    outputIndex: 0,
+                    script: '76a914293b5b9a2154a0e4543027d694276cd5fdcb74cd88ac',
+                    satoshis: 14419880000,
+                  },
+            }
+          }
         },
       },
     },
@@ -80,6 +102,31 @@ const mockedStore2 = {
       "type": 5,
       "extraPayload": "020064080000aa254fcb634bf1962b67bb64ce178a954353c71d0b6119361390a9fd1a71bd2c0000000000000000000000000000000000000000000000000000000000000000"
     }),
+    b8838022a663ae486192cf2499f9ae657e8c3a7e823a447b8b7e3d348d3916ba: new Transaction({
+      "hash": "f13a95fc3a9b6146590b12fbe48749738a1b3ffe30e42de5b1898f8f9d76b879",
+      "version": 3,
+      "inputs": [
+        {
+          "prevTxId": "0000000000000000000000000000000000000000000000000000000000000000",
+          "outputIndex": 4294967295,
+          "sequenceNumber": 4294967295,
+          "script": "0264080101"
+        }
+      ],
+      "outputs": [
+        {
+          "satoshis": 7972544484,
+          "script": "76a9144c1b05387342497e3c8fbe0b80754ae4b33134c488ac"
+        },
+        {
+          "satoshis": 7972544480,
+          "script": "76a914214035c10a2d2cef9992ca715a0115366edd229e88ac"
+        }
+      ],
+      "nLockTime": 0,
+      "type": 5,
+      "extraPayload": "020064080000aa254fcb634bf1962b67bb64ce178a954353c71d0b6119361390a9fd1a71bd2c0000000000000000000000000000000000000000000000000000000000000000"
+    }),
   }
 };
 
@@ -90,7 +137,9 @@ describe('Account - getUTXOS', function suite() {
       store: mockedStoreEmpty,
       getStore: mockedStoreEmpty,
       walletId: '123456789',
-      network: 'testnet'
+      network: 'testnet',
+      walletType: 'hdwallet',
+      BIP44PATH: "m/44'/1'/0'"
     });
     expect(utxos).to.be.deep.equal([]);
 
@@ -98,7 +147,9 @@ describe('Account - getUTXOS', function suite() {
       store: mockedStore2,
       getStore: mockedStore2,
       walletId: '123456789',
-      network: 'testnet'
+      network: 'testnet',
+      walletType: 'hdwallet',
+      BIP44PATH: "m/44'/1'/0'"
     });
 
     expect(utxos2).to.be.deep.equal([new Dashcore.Transaction.UnspentOutput(


### PR DESCRIPTION
## Issue being fixed or feature implemented

This fix https://github.com/dashevo/wallet-lib/issues/229 and might fix an issue on which we cannot sign the UTXO that we received from getUTXOS() therefore blocking creating/broadcasting some transaction.
This is specific to working with multiple account might it be during same runtime or using persistance (when on first runtime we would use account 0, and second runtime account 1). 

## What was done?
- filter HD wallet subscription path on TransactionStreamWorker.
- filter on getUTXO on HD Wallet.

## How Has This Been Tested?
- Further tests should be added in another PR to cover multiple account working with a TXStream. 

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
