### PR TITLE
chore(ci): npm tags should be formatted major.minor-dev

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -103,18 +103,15 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
-      - name: Install semver
-         run: npm install semver
-
       - name: Set release tag
         uses: actions/github-script@v3
         id: tag
         with:
           result-encoding: string
           script: |
-            const semver = require(`${process.env.GITHUB_WORKSPACE}/node_modules/semver`);
             const tag = context.payload.release.tag_name;
-            return (tag.includes('dev') ? `${semver.major(tag)}.${semver.minor(tag)}-dev` : 'latest');
+            const [, major, minor] = tag.match(/^v([0-9]+)\.([0-9]+)/)
+            return (tag.includes('dev') ? `${major}.${minor}-dev` : 'latest');
 
       - name: Publish NPM package
         uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -110,7 +110,7 @@ jobs:
           result-encoding: string
           script: |
             const tag = context.payload.release.tag_name;
-            const [, major, minor] = tag.match(/^v([0-9]+)\.([0-9]+)/)
+            const [, major, minor] = tag.match(/^v([0-9]+)\.([0-9]+)/);
             return (tag.includes('dev') ? `${major}.${minor}-dev` : 'latest');
 
       - name: Publish NPM package

--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -103,13 +103,18 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
+      - name: Install semver
+         run: npm install semver
+
       - name: Set release tag
         uses: actions/github-script@v3
         id: tag
         with:
           result-encoding: string
           script: |
-            return (context.payload.release.tag_name.includes('dev') ? 'dev' : 'latest');
+            const semver = require(`${process.env.GITHUB_WORKSPACE}/node_modules/semver`);
+            const tag = context.payload.release.tag_name;
+            return (tag.includes('dev') ? `${semver.major(tag)}.${semver.minor(tag)}-dev` : 'latest');
 
       - name: Publish NPM package
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
NPM tags were previously only `dev` or `latest`, this should now be changed to the `major.minor-dev` format for dev tags.


## What was done?
- add semver dependency
- use semver to parse proper tag and pass to NPM release step


## How Has This Been Tested?
Tested with js-dpp repo


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
