### PR TITLE
docs: fix method description for getIdentityHDKeyByIndex

### DIFF
--- a/docs/identities/getIdentityHDKeyByIndex.md
+++ b/docs/identities/getIdentityHDKeyByIndex.md
@@ -1,11 +1,11 @@
 **Usage**: `identities.getIdentityHDKeyByIndex(identityIndex, keyIndex)`      
-**Description**: This method return the identity HDKey of `identityType` for the specified `index`  
+**Description**: This method returns the identity HDKey of `identityIndex` for the specified `keyIndex`  
 
 Parameters: 
 
 | parameters          | type      | required       | Description                                                                     |  
 |---------------------|-----------|----------------| --------------------------------------------------------------------------------|
-| **index**           | number    | no             | To derive the key on a specific index (default: 0)                              |
-| **identityType**    | string    | no             | Either 'USER' or 'APPLICATION', defaults: 'USER'                                |
+| **identityIndex**   | number    | yes            | To derive the key for a specific identityIndex (default: 0)                     |
+| **keyIndex**        | number    | yes            | To derive the key for a specific keyIndex (default: 0)                          |
 
 Returns : HDKeys (private, public).


### PR DESCRIPTION
method description for getIdentityHDKeyByIndex is outdated, this PR updates the description for the current interface closes #244 