### PR TITLE
Bugfix: Fix compilation error due to typo when define Account class

### DIFF
--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -68,7 +68,7 @@ export declare class Account {
     hasPlugins([Plugin]): {found:Boolean, results:[{name: string}]};
     injectPlugin(unsafePlugin: Plugins, allowSensitiveOperation?: boolean, awaitOnInjection?: boolean): Promise<any>;
     sign(object: Transaction, privateKeys: [PrivateKey], sigType?: number): Transaction;
-    waitForInstantLock(string: transactionHash): Promise<InstantLock>;
+    waitForInstantLock(transactionHash: string): Promise<InstantLock>;
 }
 
 export declare interface RecipientOptions {


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR will fix the failed compilation due to a typo when declare a method in Account class 

![image](https://user-images.githubusercontent.com/80612076/118074779-dbfc8780-b3d8-11eb-9fe9-687595fed2ec.png)

## What was done?
Correct the  definition of method `waitForInstantLock` in Acccount.d.ts


## How Has This Been Tested?
  I rebuild the lib https://github.com/dashevo/js-dash-sdk and it works.

