### PR TITLE
refactor(Keychain)!: proper naming for BIP44 and DIP9 get keys methods

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -48,7 +48,7 @@
         - [`new KeyChain()`](keychain/KeyChain.md)
         - [`.generateKeyForChild()`](keychain/generateKeyForChild.md)
         - [`.generateKeyForPath()`](keychain/generateKeyForPath.md)
-        - [`.getHardenedBIP44Path()`](keychain/getHardenedBIP44Path.md)
+        - [`.getHardenedBIP44HDKey()`](keychain/getHardenedBIP44HDKey.md)
         - [`.getHardenedDIP9FeaturePath()`](keychain/getHardenedDIP9FeaturePath.md)
         - [`.getKeyForChild()`](keychain/getKeyForChild.md)
         - [`.getKeyForPath()`](keychain/getKeyForPath.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -49,7 +49,7 @@
         - [`.generateKeyForChild()`](keychain/generateKeyForChild.md)
         - [`.generateKeyForPath()`](keychain/generateKeyForPath.md)
         - [`.getHardenedBIP44HDKey()`](keychain/getHardenedBIP44HDKey.md)
-        - [`.getHardenedDIP9FeaturePath()`](keychain/getHardenedDIP9FeaturePath.md)
+        - [`.getHardenedDIP9FeatureHDKey()`](keychain/getHardenedDIP9FeatureHDKey.md)
         - [`.getKeyForChild()`](keychain/getKeyForChild.md)
         - [`.getKeyForPath()`](keychain/getKeyForPath.md)
         - [`.getPrivateKey()`](keychain/getPrivateKey.md)

--- a/docs/keychain/getHardenedBIP44HDKey.md
+++ b/docs/keychain/getHardenedBIP44HDKey.md
@@ -1,5 +1,5 @@
-**Usage**: `keychain.getHardenedBIP44Path(type)`    
-**Description**: Return a safier root path to derivate from
+**Usage**: `keychain.getHardenedBIP44HDKey(type)`    
+**Description**: Return a safier root key to derivate from
 
 Parameters: 
 
@@ -11,6 +11,6 @@ Returns : HDPrivateKey
 
 Example: 
 ```js
-const hdPrivateKey = keychain.getHardenedBIP44Path();
+const hdPrivateKey = keychain.getHardenedBIP44HDKey();
 const { privateKey } = hdPrivateKey
 ```

--- a/docs/keychain/getHardenedDIP9FeatureHDKey.md
+++ b/docs/keychain/getHardenedDIP9FeatureHDKey.md
@@ -1,5 +1,5 @@
-**Usage**: `keychain.getHardenedDIP9FeaturePath(type)`    
-**Description**: Return a safier root path to derivate from
+**Usage**: `keychain.getHardenedDIP9FeatureHDKey(type)`    
+**Description**: Return a safier root key to derivate from
 
 Parameters: 
 
@@ -12,7 +12,7 @@ Returns : HDPrivateKey (of path: `m/9'/1'` on testnet or `m/9'/5'` on livenet)
 Example: 
 ```js
 
-const hdPrivateKey = keychain.getHardenedDIP9FeaturePath();
+const hdPrivateKey = keychain.getHardenedDIP9FeatureHDKey();
 const { privateKey } = hdPrivateKey;
 
 ```

--- a/src/types/Identities/methods/getIdentityHDKeyByIndex.js
+++ b/src/types/Identities/methods/getIdentityHDKeyByIndex.js
@@ -8,7 +8,7 @@ const ECDSA_KEY_TYPE = 0;
  */
 function getIdentityHDKeyByIndex(identityIndex, keyIndex) {
   const { keyChain } = this;
-  const hardenedFeatureRootKey = keyChain.getHardenedDIP9FeaturePath('HDPrivateKey');
+  const hardenedFeatureRootKey = keyChain.getHardenedDIP9FeatureHDKey('HDPrivateKey');
 
   const identityFeatureKey = hardenedFeatureRootKey.deriveChild(5, true);
 

--- a/src/types/KeyChain/KeyChain.d.ts
+++ b/src/types/KeyChain/KeyChain.d.ts
@@ -22,7 +22,7 @@ export declare class KeyChain {
     generateKeyForPath(path: string, type?: HDKeyTypesParam): HDPrivateKey|HDPublicKey;
 
     getHardenedBIP44HDKey(type?: HDKeyTypesParam): HDKeyTypes;
-    getHardenedDIP9FeaturePath(type?: HDKeyTypesParam): HDKeyTypes;
+    getHardenedDIP9FeatureHDKey(type?: HDKeyTypesParam): HDKeyTypes;
 
     getKeyForChild(index: number, type?: HDKeyTypesParam): HDKeyTypes;
     getKeyForPath(path: string, type?: HDKeyTypesParam): HDKeyTypes;

--- a/src/types/KeyChain/KeyChain.d.ts
+++ b/src/types/KeyChain/KeyChain.d.ts
@@ -21,7 +21,7 @@ export declare class KeyChain {
     generateKeyForChild(index: number, type?: HDKeyTypesParam): HDPrivateKey|HDPublicKey;
     generateKeyForPath(path: string, type?: HDKeyTypesParam): HDPrivateKey|HDPublicKey;
 
-    getHardenedBIP44Path(type?: HDKeyTypesParam): HDKeyTypes;
+    getHardenedBIP44HDKey(type?: HDKeyTypesParam): HDKeyTypes;
     getHardenedDIP9FeaturePath(type?: HDKeyTypesParam): HDKeyTypes;
 
     getKeyForChild(index: number, type?: HDKeyTypesParam): HDKeyTypes;

--- a/src/types/KeyChain/KeyChain.js
+++ b/src/types/KeyChain/KeyChain.js
@@ -34,7 +34,7 @@ class KeyChain {
 
 KeyChain.prototype.generateKeyForChild = require('./methods/generateKeyForChild');
 KeyChain.prototype.generateKeyForPath = require('./methods/generateKeyForPath');
-KeyChain.prototype.getHardenedBIP44Path = require('./methods/getHardenedBIP44Path');
+KeyChain.prototype.getHardenedBIP44HDKey = require('./methods/getHardenedBIP44HDKey');
 KeyChain.prototype.getHardenedDIP9FeaturePath = require('./methods/getHardenedDIP9FeaturePath');
 KeyChain.prototype.getKeyForChild = require('./methods/getKeyForChild');
 KeyChain.prototype.getKeyForPath = require('./methods/getKeyForPath');

--- a/src/types/KeyChain/KeyChain.js
+++ b/src/types/KeyChain/KeyChain.js
@@ -35,7 +35,7 @@ class KeyChain {
 KeyChain.prototype.generateKeyForChild = require('./methods/generateKeyForChild');
 KeyChain.prototype.generateKeyForPath = require('./methods/generateKeyForPath');
 KeyChain.prototype.getHardenedBIP44HDKey = require('./methods/getHardenedBIP44HDKey');
-KeyChain.prototype.getHardenedDIP9FeaturePath = require('./methods/getHardenedDIP9FeaturePath');
+KeyChain.prototype.getHardenedDIP9FeatureHDKey = require('./methods/getHardenedDIP9FeatureHDKey');
 KeyChain.prototype.getKeyForChild = require('./methods/getKeyForChild');
 KeyChain.prototype.getKeyForPath = require('./methods/getKeyForPath');
 KeyChain.prototype.getPrivateKey = require('./methods/getPrivateKey');

--- a/src/types/KeyChain/KeyChain.spec.js
+++ b/src/types/KeyChain/KeyChain.spec.js
@@ -27,22 +27,27 @@ describe('Keychain', function suite() {
     const address = new Dashcore.Address(pk2.publicKey.toAddress()).toString();
     expect(address).to.equal('yNfUebksUc5HoSfg8gv98ruC3jUNJUM8pT');
   });
-  it('should get hardened feature path', () => {
-    const hardenedPk = keychain.getHardenedBIP44HDKey();
-    const pk2 = keychain.getKeyForPath('m/44\'/1\'');
-    expect(pk2.toString()).to.equal(hardenedPk.toString());
-  });
   it('should derive from hardened feature path', () => {
-    const hardenedPk = keychain.getHardenedBIP44HDKey();
-    const derivedPk = hardenedPk.deriveChild(0, true).deriveChild(0).deriveChild(0);
+    const hardenedHDKey = keychain.getHardenedBIP44HDKey();
+    const pk2 = keychain.getKeyForPath(`m/44'/1'`);
+    expect(pk2.toString()).to.equal(hardenedHDKey.toString());
+    expect(hardenedHDKey.toString()).to.deep.equal('tprv8dtrJNytYHRiZY585hmHGbguS6VjGpK49puSB7oXZjLHcQfrAzQkF4ZCxM2DkEbyY85J4EYcZ8EjT5ZCU8ozB727TDdodbfXet5GkGau2RQ');
+    const derivedPk = hardenedHDKey.deriveChild(0, true).deriveChild(0).deriveChild(0);
     const address = new Dashcore.Address(derivedPk.publicKey.toAddress()).toString();
     expect(address).to.equal('yNfUebksUc5HoSfg8gv98ruC3jUNJUM8pT');
+  });
+  it('should get hardened DIP9FeatureHDKey', function () {
+    const hardenedHDKey = keychain.getHardenedDIP9FeatureHDKey();
+    const pk2 = keychain.getKeyForPath(`m/9'/1'`);
+    expect(pk2.toString()).to.equal(hardenedHDKey.toString());
+    expect(hardenedHDKey.toString()).to.deep.equal('tprv8fBJjWoGgCpGRCbyzE9RUA59rmoN1RUijhLnXGL4VHnLxvSe523yVg4GrGzbR6TyXtdynAEh5z8UX55EXt2Cb3xjvrsx2PgTY9BHxzFVkWn');
   });
   it('should generate key for child', () => {
     const keychain2 = new KeyChain({ HDPrivateKey: mnemonicToHDPrivateKey(mnemonic, 'testnet') });
     const keyForChild = keychain2.generateKeyForChild(0);
     expect(keyForChild.toString()).to.equal('tprv8d4podc2Tg459CH2bwLHXj3vdJFBT2rdsk5Nr1djH7hzHdt5LRdvN6QyFwMiDy7ffRdik7fEVRKKgsHB4F18sh8xF6jFXpKq4sUgGBoSbKw');
   });
+
 
   it('should sign', () => {
 

--- a/src/types/KeyChain/KeyChain.spec.js
+++ b/src/types/KeyChain/KeyChain.spec.js
@@ -28,12 +28,12 @@ describe('Keychain', function suite() {
     expect(address).to.equal('yNfUebksUc5HoSfg8gv98ruC3jUNJUM8pT');
   });
   it('should get hardened feature path', () => {
-    const hardenedPk = keychain.getHardenedBIP44Path();
+    const hardenedPk = keychain.getHardenedBIP44HDKey();
     const pk2 = keychain.getKeyForPath('m/44\'/1\'');
     expect(pk2.toString()).to.equal(hardenedPk.toString());
   });
   it('should derive from hardened feature path', () => {
-    const hardenedPk = keychain.getHardenedBIP44Path();
+    const hardenedPk = keychain.getHardenedBIP44HDKey();
     const derivedPk = hardenedPk.deriveChild(0, true).deriveChild(0).deriveChild(0);
     const address = new Dashcore.Address(derivedPk.publicKey.toAddress()).toString();
     expect(address).to.equal('yNfUebksUc5HoSfg8gv98ruC3jUNJUM8pT');

--- a/src/types/KeyChain/methods/getHardenedBIP44HDKey.js
+++ b/src/types/KeyChain/methods/getHardenedBIP44HDKey.js
@@ -1,12 +1,12 @@
 const { BIP44_TESTNET_ROOT_PATH, BIP44_LIVENET_ROOT_PATH } = require('../../../CONSTANTS');
 
 /**
- * Return a safier root path to derivate from
+ * Return a safier root keys to derivate from
  * @param {HDPrivateKey|HDPublicKey} [type=HDPrivateKey] - set the type of returned keys
  * @return {HDPrivateKey|HDPublicKey}
  */
-function getHardenedBIP44Path(type = 'HDPrivateKey') {
+function getHardenedBIP44HDKey(type = 'HDPrivateKey') {
   const pathRoot = (this.network.toString() === 'testnet') ? BIP44_TESTNET_ROOT_PATH : BIP44_LIVENET_ROOT_PATH;
   return this.generateKeyForPath(pathRoot, type);
 }
-module.exports = getHardenedBIP44Path;
+module.exports = getHardenedBIP44HDKey;

--- a/src/types/KeyChain/methods/getHardenedDIP9FeatureHDKey.js
+++ b/src/types/KeyChain/methods/getHardenedDIP9FeatureHDKey.js
@@ -5,8 +5,8 @@ const { DIP9_LIVENET_ROOT_PATH, DIP9_TESTNET_ROOT_PATH } = require('../../../CON
  * @param {HDPrivateKey|HDPublicKey} [type=HDPrivateKey] - set the type of returned keys
  * @return {HDPrivateKey|HDPublicKey}
  */
-function getHardenedDIP9FeaturePath(type = 'HDPrivateKey') {
+function getHardenedDIP9FeatureHDKey(type = 'HDPrivateKey') {
   const pathRoot = (this.network.toString() === 'testnet') ? DIP9_TESTNET_ROOT_PATH : DIP9_LIVENET_ROOT_PATH;
   return this.generateKeyForPath(pathRoot, type);
 }
-module.exports = getHardenedDIP9FeaturePath;
+module.exports = getHardenedDIP9FeatureHDKey;


### PR DESCRIPTION
## Issue being fixed or feature implemented

This breaking change PR bring a small naming update, indeed we had getHardenedBIP44Path and getDIP9FeaturePath methods that directly returns keys. 
As naming is documentation by itself, this modification will better reflect expected comportment of those methods. 

## What was done?
- renamed getHardenedBIP44Path to getHardenedBIP44HDKey
- renamed getHardenedDIP9FeaturePath to getHardenedDIP9FeatureHDKey
- added missing test for getHardenedDIP9FeatureHDKey

## How Has This Been Tested?
- Added new test

## Breaking Changes
-  `getHardenedBIP44Path` renamed to `getHardenedBIP44HDKey`
- `getHardenedDIP9FeaturePath` renamed to  `getHardenedDIP9FeatureHDKey`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
