### PR TITLE
feat: prevent broadcast and throw error on transaction below min relay fee

### DIFF
--- a/docs/account/broadcastTransaction.md
+++ b/docs/account/broadcastTransaction.md
@@ -4,10 +4,11 @@
 
 Parameters: 
 
-| parameters             | type               | required       | Description                                                                                      |  
-|------------------------|--------------------|----------------| ------------------------------------------------------------------------------------------------ |
-| **transaction**        | Transaction/String | yes            | A valid [created transaction](/account/createTransaction) or it's hexadecimal raw representation |
-| **forceBroadcast**     | Boolean            | no[=false]     | When set to true, and min relay fee is not met, will still try to broadcast a transaction        |
+| parameters                        | type               | required       | Description                                                                                      |  
+|-----------------------------------|--------------------|----------------| ------------------------------------------------------------------------------------------------ |
+| **transaction**                   | Transaction/String | yes            | A valid [created transaction](/account/createTransaction) or it's hexadecimal raw representation |
+| **options**                       | Object             | no             | |
+| **options.skipFeeValidation**     | Boolean            | no             | When set to true, and min relay fee is not met, will still try to broadcast a transaction        |
 
 Returns : transactionId (string).
 

--- a/docs/account/broadcastTransaction.md
+++ b/docs/account/broadcastTransaction.md
@@ -7,6 +7,7 @@ Parameters:
 | parameters             | type               | required       | Description                                                                                      |  
 |------------------------|--------------------|----------------| ------------------------------------------------------------------------------------------------ |
 | **transaction**        | Transaction/String | yes            | A valid [created transaction](/account/createTransaction) or it's hexadecimal raw representation |
+| **forceBroadcast**     | Boolean            | no[=false]     | When set to true, and min relay fee is not met, will still try to broadcast a transaction        |
 
 Returns : transactionId (string).
 

--- a/docs/account/createTransaction.md
+++ b/docs/account/createTransaction.md
@@ -55,3 +55,29 @@ const tx2 = account.createTransaction(txOpts2);
 ```
 
 See more information about [coinSelection](/usage/coinSelection).
+
+## Deduct Fee 
+
+In order to broadcast a transaction, a minimal relay fee is required for a node to accept to broadcast the transaction.  
+
+Such fee are used as a spam mechanism protection as a standard transaction would require slightly more than 0.0000012 Dash (varies per transaction and per node) as relay fee.  
+
+The deduct fee property, when set at true allows to automatically estimate the size and deduct from outputs the corresponding amount.  
+
+In case one user would want to not see that, he will be required to select an input to pay a fee by himself. 
+
+Expected minimal relay fee for your transaction can be estimated this way : 
+
+```js 
+const { storage, network } = account;
+const { chains } = storage.getStore();
+const txOpts = {
+deductFee: false,
+}
+const transaction = account.createTransaction(txOpts);
+
+const { minRelay: minRelayFeeRate } = chains[network.toString()].fees;
+
+const estimateKbSize = transaction._estimateSize() / 1000;
+const minFeeToPay = estimateKbSize * minRelayFeeRate;
+```

--- a/src/plugins/Plugins/ChainPlugin.js
+++ b/src/plugins/Plugins/ChainPlugin.js
@@ -69,7 +69,10 @@ class ChainPlugin extends StandardPlugin {
     logger.debug('ChainPlugin - Setting up starting blockHeight', blocks);
 
     this.storage.store.chains[network.toString()].blockHeight = blocks;
-    this.storage.store.chains[network.toString()].fees.minRelay = dashToDuffs(relay);
+
+    if (relay) {
+      this.storage.store.chains[network.toString()].fees.minRelay = dashToDuffs(relay);
+    }
 
     const bestBlock = await this.transport.getBlockHeaderByHeight(blocks);
     await this.storage.importBlockHeader(bestBlock);

--- a/src/plugins/Plugins/ChainPlugin.js
+++ b/src/plugins/Plugins/ChainPlugin.js
@@ -1,6 +1,7 @@
 const logger = require('../../logger');
 const { StandardPlugin } = require('..');
 const EVENTS = require('../../EVENTS');
+const { dashToDuffs } = require('../../utils');
 
 const defaultOpts = {
   firstExecutionRequired: true,
@@ -61,13 +62,14 @@ class ChainPlugin extends StandardPlugin {
       return false;
     }
 
-    const { chain: { blocksCount: blocks } } = res;
+    const { chain: { blocksCount: blocks }, network: { fee: { relay } } } = res;
 
     const { network } = this.storage.store.wallets[this.walletId];
 
     logger.debug('ChainPlugin - Setting up starting blockHeight', blocks);
 
     this.storage.store.chains[network.toString()].blockHeight = blocks;
+    this.storage.store.chains[network.toString()].fees.minRelay = dashToDuffs(relay);
 
     const bestBlock = await this.transport.getBlockHeaderByHeight(blocks);
     await this.storage.importBlockHeader(bestBlock);

--- a/src/types/Account/Account.d.ts
+++ b/src/types/Account/Account.d.ts
@@ -8,6 +8,7 @@ import {
     PrivateKey,
     Strategy,
     Network,
+    broadcastTransactionOpts,
     Plugins, RawTransaction, TransactionsMap, WalletObj, StatusInfo
 } from "../types";
 import { KeyChain } from "../KeyChain/KeyChain";
@@ -42,7 +43,7 @@ export declare class Account {
     getBIP44Path(network?: Network, index?: number): string;
     getNetwork(): Network;
 
-    broadcastTransaction(rawtx: Transaction|RawTransaction): Promise<transactionId>;
+    broadcastTransaction(rawtx: Transaction|RawTransaction, options?: broadcastTransactionOpts): Promise<transactionId>;
     connect(): boolean;
     createTransaction(opts: Account.createTransactionOptions): Transaction;
     decode(method: string, data: any): any;

--- a/src/types/Account/methods/broadcastTransaction.js
+++ b/src/types/Account/methods/broadcastTransaction.js
@@ -67,7 +67,7 @@ async function broadcastTransaction(transaction, options = {}) {
   const estimateKbSize = transaction._estimateSize() / 1000;
   const minRelayFee = Math.ceil(estimateKbSize * minRelayFeeRate);
 
-  if (minRelayFee > transaction.getFee() && !options.skipFeeValiation) {
+  if (minRelayFee > transaction.getFee() && !options.skipFeeValidation) {
     throw new Error(`Expected minimum fee for transaction ${minRelayFee}. Current: ${transaction.getFee()}`);
   }
   const serializedTransaction = transaction.toString();

--- a/src/types/Account/methods/broadcastTransaction.js
+++ b/src/types/Account/methods/broadcastTransaction.js
@@ -36,10 +36,10 @@ function impactAffectedInputs({ inputs }) {
 /**
  * Broadcast a Transaction to the transport layer
  * @param {Transaction|RawTransaction} transaction - A txobject or it's hexadecimal representation
- * @param {isBoolean=false} forceBroadcast - Allow to force broadcast on error.
+ * @param {Boolean} options.skipFeeValidation - Allow to skip fee validation
  * @return {Promise<transactionId>}
  */
-async function broadcastTransaction(transaction, forceBroadcast = false) {
+async function broadcastTransaction(transaction, options = {}) {
   const { network, storage } = this;
   const { chains } = storage.getStore();
   if (!this.transport) throw new ValidTransportLayerRequired('broadcast');
@@ -67,7 +67,7 @@ async function broadcastTransaction(transaction, forceBroadcast = false) {
   const estimateKbSize = transaction._estimateSize() / 1000;
   const minRelayFee = Math.ceil(estimateKbSize * minRelayFeeRate);
 
-  if (minRelayFee > transaction.getFee() && !forceBroadcast) {
+  if (minRelayFee > transaction.getFee() && !options.skipFeeValiation) {
     throw new Error(`Expected minimum fee for transaction ${minRelayFee}. Current: ${transaction.getFee()}`);
   }
   const serializedTransaction = transaction.toString();

--- a/src/types/Account/methods/broadcastTransaction.js
+++ b/src/types/Account/methods/broadcastTransaction.js
@@ -36,7 +36,8 @@ function impactAffectedInputs({ inputs }) {
 /**
  * Broadcast a Transaction to the transport layer
  * @param {Transaction|RawTransaction} transaction - A txobject or it's hexadecimal representation
- * @param {Boolean} options.skipFeeValidation - Allow to skip fee validation
+ * @param {Object} [options]
+ * @param {Boolean} [options.skipFeeValidation=false] - Allow to skip fee validation
  * @return {Promise<transactionId>}
  */
 async function broadcastTransaction(transaction, options = {}) {

--- a/src/types/Account/methods/broadcastTransaction.js
+++ b/src/types/Account/methods/broadcastTransaction.js
@@ -40,7 +40,8 @@ function impactAffectedInputs({ inputs }) {
  * @return {Promise<transactionId>}
  */
 async function broadcastTransaction(transaction, forceBroadcast = false) {
-  const { chains } = this.storage.getStore();
+  const { network, storage } = this;
+  const { chains } = storage.getStore();
   if (!this.transport) throw new ValidTransportLayerRequired('broadcast');
 
   // We still support having in rawtransaction, if this is the case
@@ -60,11 +61,11 @@ async function broadcastTransaction(transaction, forceBroadcast = false) {
   }
 
   const { inputs } = transaction.toObject();
-  const { minRelay: minRelayFeeRate } = chains[this.network.toString()].fees;
+  const { minRelay: minRelayFeeRate } = chains[network.toString()].fees;
 
   // eslint-disable-next-line no-underscore-dangle
   const estimateKbSize = transaction._estimateSize() / 1000;
-  const minRelayFee = estimateKbSize * minRelayFeeRate;
+  const minRelayFee = Math.ceil(estimateKbSize * minRelayFeeRate);
 
   if (minRelayFee > transaction.getFee() && !forceBroadcast) {
     throw new Error(`Expected minimum fee for transaction ${minRelayFee}. Current: ${transaction.getFee()}`);

--- a/src/types/Account/methods/broadcastTransaction.js
+++ b/src/types/Account/methods/broadcastTransaction.js
@@ -36,9 +36,10 @@ function impactAffectedInputs({ inputs }) {
 /**
  * Broadcast a Transaction to the transport layer
  * @param {Transaction|RawTransaction} transaction - A txobject or it's hexadecimal representation
+ * @param {isBoolean=false} forceBroadcast - Allow to force broadcast on error.
  * @return {Promise<transactionId>}
  */
-async function broadcastTransaction(transaction) {
+async function broadcastTransaction(transaction, forceBroadcast = false) {
   if (!this.transport) throw new ValidTransportLayerRequired('broadcast');
 
   // We still support having in rawtransaction, if this is the case

--- a/src/types/Account/methods/broadcastTransaction.spec.js
+++ b/src/types/Account/methods/broadcastTransaction.spec.js
@@ -162,7 +162,7 @@ describe('Account - broadcastTransaction', function suite() {
     tx.fee(0);
 
     return broadcastTransaction
-        .call(self, tx, true)
+        .call(self, tx, {skipFeeValidation: true})
         .then(
             () => expect(sendCalled).to.equal(1) && expect(searchCalled).to.equal(1),
         );

--- a/src/types/Account/methods/broadcastTransaction.spec.js
+++ b/src/types/Account/methods/broadcastTransaction.spec.js
@@ -14,7 +14,13 @@ describe('Account - broadcastTransaction', function suite() {
   let keysToSign;
   let oneToOneTx;
   let fee;
-
+  const storage = {
+    getStore: ()=>({
+      chains:{
+          "testnet": { fees: { minRelay: 888 }}
+      }
+    })
+  }
   beforeEach(() => {
     utxos = [
       {
@@ -41,6 +47,8 @@ describe('Account - broadcastTransaction', function suite() {
     const expectedException1 = 'A transport layer is needed to perform a broadcast';
     const self = {
       transport: null,
+      storage,
+      network: 'testnet'
     };
     expectThrowsAsync(async () => await broadcastTransaction.call(self, validRawTxs.tx2to2Testnet), expectedException1);
 
@@ -55,6 +63,8 @@ describe('Account - broadcastTransaction', function suite() {
     const expectedException1 = 'A valid transaction object or it\'s hex representation is required';
     const self = {
       transport: { },
+      storage,
+      network: 'testnet'
     };
 
     expectThrowsAsync(async () => await broadcastTransaction.call(self, invalidRawTxs.notRelatedString), expectedException1);
@@ -63,6 +73,8 @@ describe('Account - broadcastTransaction', function suite() {
     const expectedException1 = 'A valid transaction object or it\'s hex representation is required';
     const self = {
       transport: { },
+      storage,
+      network: 'testnet'
     };
 
     expectThrowsAsync(async () => await broadcastTransaction.call(self, invalidRawTxs.truncatedRawTx), expectedException1);
@@ -74,7 +86,9 @@ describe('Account - broadcastTransaction', function suite() {
       transport: {
         sendTransaction: () => sendCalled = +1,
       },
+      network: 'testnet',
       storage: {
+        getStore: storage.getStore,
         searchAddress: () => { searchCalled = +1; return { found: false }; },
         searchAddressesWithTx: () => { searchCalled = +1; return { results: [] }; },
       },
@@ -94,7 +108,9 @@ describe('Account - broadcastTransaction', function suite() {
       transport: {
         sendTransaction: () => sendCalled = +1,
       },
+      network: 'testnet',
       storage: {
+        getStore: storage.getStore,
         searchAddress: () => { searchCalled = +1; return { found: false }; },
         searchAddressesWithTx: (affectedTxId) => { searchCalled = +1; return { results: [] }; },
       },
@@ -105,5 +121,50 @@ describe('Account - broadcastTransaction', function suite() {
       .then(
         () => expect(sendCalled).to.equal(1) && expect(searchCalled).to.equal(1),
       );
+  });
+  it('should throw error on fee not met', function () {
+    const expectedException1 = 'Expected minimum fee for transaction 149. Current: 0\n';
+
+    let sendCalled = +1;
+    let searchCalled = +1;
+    const self = {
+      transport: {
+        sendTransaction: () => sendCalled = +1,
+      },
+      network: 'testnet',
+      storage: {
+        getStore: storage.getStore,
+        searchAddress: () => { searchCalled = +1; return { found: false }; },
+        searchAddressesWithTx: () => { searchCalled = +1; return { results: [] }; },
+      },
+    };
+
+    const tx = oneToOneTx;
+    tx.fee(0);
+    expectThrowsAsync(async () => await broadcastTransaction.call(self, invalidRawTxs.truncatedRawTx), expectedException1);
+  });
+  it('should broadcast when force and fee not met', function () {
+    let sendCalled = +1;
+    let searchCalled = +1;
+    const self = {
+      transport: {
+        sendTransaction: () => sendCalled = +1,
+      },
+      network: 'testnet',
+      storage: {
+        getStore: storage.getStore,
+        searchAddress: () => { searchCalled = +1; return { found: false }; },
+        searchAddressesWithTx: () => { searchCalled = +1; return { results: [] }; },
+      },
+    };
+
+    const tx = oneToOneTx;
+    tx.fee(0);
+
+    return broadcastTransaction
+        .call(self, tx, true)
+        .then(
+            () => expect(sendCalled).to.equal(1) && expect(searchCalled).to.equal(1),
+        );
   });
 });

--- a/src/types/Storage/Storage.spec.js
+++ b/src/types/Storage/Storage.spec.js
@@ -56,7 +56,13 @@ describe('Storage - constructor', function suite() {
       transactionsMetadata:{},
       chains: {
         testnet: {
-          name: 'testnet', blockHeight: -1, blockHeaders: {}, mappedBlockHeaderHeights: {},
+          name: 'testnet',
+          blockHeight: -1,
+          blockHeaders: {},
+          mappedBlockHeaderHeights: {},
+          fees: {
+            minRelay: -1
+          }
         },
       },
       instantLocks: {}
@@ -79,7 +85,13 @@ describe('Storage - constructor', function suite() {
       transactionsMetadata: {},
       chains: {
         testnet: {
-          name: 'testnet', blockHeight: -1, blockHeaders: {}, mappedBlockHeaderHeights: {},
+          name: 'testnet',
+          blockHeight: -1,
+          blockHeaders: {},
+          mappedBlockHeaderHeights: {},
+          fees: {
+            minRelay: -1
+          }
         },
       },
       instantLocks: {},

--- a/src/types/Storage/methods/createChain.js
+++ b/src/types/Storage/methods/createChain.js
@@ -13,6 +13,10 @@ const createChain = function createChain(network) {
       // Map a blockheader to it's height (used by searchBlockheader for speed up the process)
       mappedBlockHeaderHeights: {},
       blockHeight: -1,
+      fees: {
+        // feeRate expressed per kb
+        minRelay: -1,
+      },
     };
     return true;
   }

--- a/src/types/Storage/methods/createChain.spec.js
+++ b/src/types/Storage/methods/createChain.spec.js
@@ -15,7 +15,13 @@ describe('Storage - createChain', function suite() {
       store: {
         chains: {
           testnet: {
-            name: 'testnet', blockHeight: -1, blockHeaders: {}, mappedBlockHeaderHeights: {},
+            name: 'testnet',
+            blockHeight: -1,
+            blockHeaders: {},
+            mappedBlockHeaderHeights: {},
+            fees: {
+              minRelay: -1
+            }
           },
         },
       },

--- a/src/types/Storage/methods/createWallet.spec.js
+++ b/src/types/Storage/methods/createWallet.spec.js
@@ -27,7 +27,13 @@ describe('Storage - createWallet', function suite() {
       },
       chains: {
         testnet: {
-          name: 'testnet', blockHeight: -1, blockHeaders: {}, mappedBlockHeaderHeights: {},
+          name: 'testnet',
+          blockHeight: -1,
+          blockHeaders: {},
+          mappedBlockHeaderHeights: {},
+          fees: {
+            minRelay: -1
+          }
         },
       },
     };
@@ -54,7 +60,13 @@ describe('Storage - createWallet', function suite() {
       },
       chains: {
         testnet: {
-          name: 'testnet', blockHeight: -1, blockHeaders: {}, mappedBlockHeaderHeights: {},
+          name: 'testnet',
+          blockHeight: -1,
+          blockHeaders: {},
+          mappedBlockHeaderHeights: {},
+          fees: {
+            minRelay: -1
+          }
         },
       },
     };

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -59,7 +59,9 @@ export declare type AddressObj<T extends object = object> = T & {
 export declare type AddressInfoMap<T extends object = object> = T & {
     [pathName: string]: AddressInfo
 }
-
+export declare type broadcastTransactionOpts<T extends object = object> = T & {
+    skipFeeValidation?: boolean
+}
 export declare type AddressInfo<T extends AddressObj = AddressObj> = T & {
     path: string;
     address: string;


### PR DESCRIPTION
## Issue being fixed or feature implemented

This PR aim to better address and explain how deductFee works as #228 issue highlight that proper explanation and handling of such case would be needed.
As when deductFee is set to false, we expect user to manage the addition of the fee by himself manipulating the transaction object, it was required to provide a snippet in documentation to help such endeavour. 
Additionnally, we will now store the minimal relay fee rate and verify before broadcasting a transaction that it is being met. 

## What was done?
- feat: add min relay fee in chain store
- feat: add forceBroadcast property
- feat: verify minimum relay fee rate is met before broadcasting a transaction
- doc provide explanation and snippet for fee setting to users 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with SDK's CI

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
