### PR TITLE
fix: correctly announced when a plugin is initialized.

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,4 +1,4 @@
-DRIVE_BRANCH=update-dpp
+#DRIVE_BRANCH=update-dpp
 #DAPI_BRANCH=send-metadata-buffer
-DASHMATE_BRANCH=update-dpp
-TEST_SUITE_BRANCH=update-dpp
+#DASHMATE_BRANCH=update-dpp
+#TEST_SUITE_BRANCH=update-dpp

--- a/src/types/Account/_initializeAccount.js
+++ b/src/types/Account/_initializeAccount.js
@@ -67,14 +67,16 @@ async function _initializeAccount(account, userUnsafePlugins) {
         }
       };
 
+      let readyPlugins = 0;
       // eslint-disable-next-line no-param-reassign,consistent-return
       account.readinessInterval = setInterval(() => {
         const watchedPlugins = Object.keys(account.plugins.watchers);
-        let readyPlugins = 0;
         watchedPlugins.forEach((pluginName) => {
-          if (account.plugins.watchers[pluginName].ready === true) {
+          const watchedPlugin = account.plugins.watchers[pluginName];
+          if (watchedPlugin.ready === true && !watchedPlugin.announced) {
             logger.debug(`Initializing - ${readyPlugins}/${watchedPlugins.length} plugins`);
             readyPlugins += 1;
+            watchedPlugin.announced = true;
             logger.debug(`Initialized ${pluginName} - ${readyPlugins}/${watchedPlugins.length} plugins`);
           }
         });

--- a/src/types/Account/methods/injectPlugin.js
+++ b/src/types/Account/methods/injectPlugin.js
@@ -78,6 +78,7 @@ module.exports = async function injectPlugin(
               const watcher = {
                 ready: false,
                 started: false,
+                announced: false,
               };
               self.plugins.watchers[pluginName] = watcher;
 
@@ -103,6 +104,7 @@ module.exports = async function injectPlugin(
               const watcher = {
                 ready: false,
                 started: false,
+                announced: false,
               };
               self.plugins.watchers[pluginName] = watcher;
               // eslint-disable-next-line no-return-assign,no-param-reassign,max-len


### PR DESCRIPTION
## Issue being fixed or feature implemented

A small issue existed when we wrongly were always announcing the same plugin as being initialized, this PR fix that situation.

## What was done?
-fix: announcement of initializing and initialized plugins.

## How Has This Been Tested?
- existing tests

## Breaking Changes
N/A


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
