### PR TITLE
fix: avoid trying to cancel already cancelled stream

### DIFF
--- a/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
@@ -170,7 +170,7 @@ class TransactionSyncStreamWorker extends Worker {
     // explained here (https://github.com/grpc/grpc-node/issues/1652)
     // and here (https://github.com/nodejs/node/issues/38964)
     return new Promise((resolve) => setImmediate(() => {
-      if (this.stream && this.stream.cancel) {
+      if (this.stream) {
         this.stream.cancel();
         // When calling stream.cancel(), the stream will emit 'error' event
         // with the code 'CANCELLED'.

--- a/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
@@ -166,11 +166,11 @@ class TransactionSyncStreamWorker extends Worker {
     }
     this.syncIncomingTransactions = false;
 
-    if (this.stream) {
-      // Wrapping `cancel` in `setImmediate` due to bug with double-free
-      // explained here (https://github.com/grpc/grpc-node/issues/1652)
-      // and here (https://github.com/nodejs/node/issues/38964)
-      return new Promise((resolve) => setImmediate(() => {
+    // Wrapping `cancel` in `setImmediate` due to bug with double-free
+    // explained here (https://github.com/grpc/grpc-node/issues/1652)
+    // and here (https://github.com/nodejs/node/issues/38964)
+    return new Promise((resolve) => setImmediate(() => {
+      if (this.stream && this.stream.cancel) {
         this.stream.cancel();
         // When calling stream.cancel(), the stream will emit 'error' event
         // with the code 'CANCELLED'.
@@ -181,11 +181,9 @@ class TransactionSyncStreamWorker extends Worker {
         // that the old stream object is present or not. When it is set to null, it won't try to
         // reconnect to the stream.
         this.stream = null;
-
-        resolve(true);
-      }));
-    }
-    return true;
+      }
+      resolve(true);
+    }));
   }
 
   setLastSyncedBlockHash(hash) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

This PR fixes an issue with TransactionStreamWorker when trying to close an already closed stream which would then throw a 
`Uncaught TypeError: Cannot read properties of null (reading ‘cancel’)`

## What was done?
- fix: avoid trying to cancel an already cancelled stream

## How Has This Been Tested?
- Using test-suite (display [RUN](https://github.com/dashevo/js-dash-sdk/actions/runs/1319791764))

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
