### PR TITLE
fix: grpc-web doesn't throws cancel error

### DIFF
--- a/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
@@ -1,13 +1,10 @@
 const {
   Transaction, MerkleBlock, InstantLock,
 } = require('@dashevo/dashcore-lib');
-const GrpcError = require('@dashevo/grpc-common/lib/server/error/GrpcError');
-const GrpcErrorCodes = require('@dashevo/grpc-common/lib/server/error/GrpcErrorCodes');
 const { WALLET_TYPES } = require('../../../CONSTANTS');
 const sleep = require('../../../utils/sleep');
 
 const Worker = require('../../Worker');
-const isBrowser = require('../../../utils/isBrowser');
 
 class TransactionSyncStreamWorker extends Worker {
   constructor(options) {
@@ -169,19 +166,6 @@ class TransactionSyncStreamWorker extends Worker {
       return this.onStop();
     }
     this.syncIncomingTransactions = false;
-
-    if (isBrowser()) {
-      // Under browser environment, grpc-web doesn't throw cancel error
-      // so we throw it by ourselves
-      if (this.stream) {
-        this.stream.cancel();
-        this.stream = null;
-
-        throw new GrpcError(GrpcErrorCodes.CANCELLED, 'Cancelled on client');
-      }
-
-      return true;
-    }
 
     // Wrapping `cancel` in `setImmediate` due to bug with double-free
     // explained here (https://github.com/grpc/grpc-node/issues/1652)

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/processChunks.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/processChunks.js
@@ -55,11 +55,19 @@ async function processChunks(dataChunk) {
       logger.silly('TransactionSyncStreamWorker - end stream - new addresses generated');
 
       if (isBrowser()) {
-        // Under browser environment, grpc-web doesn't throw cancel error
-        // so we throw it by ourselves
-        self.stream.cancel();
+        // Under browser environment, grpc-web doesn't call error and end events
+        // so we call it by ourselves
+        await new Promise((resolveCancel) => setImmediate(() => {
+          self.stream.cancel();
+          const error = new GrpcError(GrpcErrorCodes.CANCELLED, 'Cancelled on client');
 
-        throw new GrpcError(GrpcErrorCodes.CANCELLED, 'Cancelled on client');
+          // call onError events
+          self.stream.f.forEach((func) => func(error));
+
+          // call onEnd events
+          self.stream.c.forEach((func) => func());
+          resolveCancel();
+        }));
       } else {
         // If there are some new addresses being imported
         // to the storage, that mean that we hit the gap limit

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/processChunks.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/processChunks.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-param-reassign */
+const GrpcError = require('@dashevo/grpc-common/lib/server/error/GrpcError');
+const GrpcErrorCodes = require('@dashevo/grpc-common/lib/server/error/GrpcErrorCodes');
 const logger = require('../../../../logger');
+const isBrowser = require('../../../../utils/isBrowser');
 
 function isAnyIntersection(arrayA, arrayB) {
   const intersection = arrayA.filter((e) => arrayB.indexOf(e) > -1);
@@ -50,21 +53,30 @@ async function processChunks(dataChunk) {
 
     if (self.hasReachedGapLimit && self.stream) {
       logger.silly('TransactionSyncStreamWorker - end stream - new addresses generated');
-      // If there are some new addresses being imported
-      // to the storage, that mean that we hit the gap limit
-      // and we need to update the bloom filter with new addresses,
-      // i.e. we need to open another stream with a bloom filter
-      // that contains new addresses.
 
-      // DO not setting null this.stream allow to know we
-      // need to reset our stream (as we pass along the error)
-      // Wrapping `cancel` in `setImmediate` due to bug with double-free
-      // explained here (https://github.com/grpc/grpc-node/issues/1652)
-      // and here (https://github.com/nodejs/node/issues/38964)
-      await new Promise((resolveCancel) => setImmediate(() => {
+      if (isBrowser()) {
+        // Under browser environment, grpc-web doesn't throw cancel error
+        // so we throw it by ourselves
         self.stream.cancel();
-        resolveCancel();
-      }));
+
+        throw new GrpcError(GrpcErrorCodes.CANCELLED, 'Cancelled on client');
+      } else {
+        // If there are some new addresses being imported
+        // to the storage, that mean that we hit the gap limit
+        // and we need to update the bloom filter with new addresses,
+        // i.e. we need to open another stream with a bloom filter
+        // that contains new addresses.
+
+        // DO not setting null this.stream allow to know we
+        // need to reset our stream (as we pass along the error)
+        // Wrapping `cancel` in `setImmediate` due to bug with double-free
+        // explained here (https://github.com/grpc/grpc-node/issues/1652)
+        // and here (https://github.com/nodejs/node/issues/38964)
+        await new Promise((resolveCancel) => setImmediate(() => {
+          self.stream.cancel();
+          resolveCancel();
+        }));
+      }
     }
   }
 

--- a/src/plugins/Workers/TransactionSyncStreamWorker/methods/syncUpToTheGapLimit.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/methods/syncUpToTheGapLimit.js
@@ -41,7 +41,7 @@ module.exports = async function syncUpToTheGapLimit({
   self.network = network;
   self.hasReachedGapLimit = false;
   // The order is important, however, some async calls are being performed
-  // in order to additionnaly fetch metadata for each valid tx chunks.
+  // in order to additionally fetch metadata for each valid tx chunks.
   // We therefore need to temporarily store chunks for handling.
   self.chunksQueue = new Queue();
 

--- a/src/test/mocks/TxStreamMock.js
+++ b/src/test/mocks/TxStreamMock.js
@@ -1,6 +1,15 @@
 const EventEmitter = require('events');
 
 class TxStreamMock extends EventEmitter {
+  constructor() {
+    super();
+
+    // onError minified events list
+    this.f = [];
+    // onEnd minified events list
+    this.c = [];
+  }
+
   cancel() {
     const err = new Error();
     err.code = 2;

--- a/src/transport/DAPIClientTransport/methods/subscribeToTransactionsWithProofs.js
+++ b/src/transport/DAPIClientTransport/methods/subscribeToTransactionsWithProofs.js
@@ -16,7 +16,7 @@ const { BLOOM_FALSE_POSITIVE_RATE } = require('../../../CONSTANTS');
  * @return {Promise<void>}
  */
 
-module.exports = async function subscribeToTransactionWithProofs(
+module.exports = async function subscribeToTransactionsWithProofs(
   addressList,
   opts = { fromBlockHeight: 1, count: 0 },
 ) {

--- a/src/utils/isBrowser.js
+++ b/src/utils/isBrowser.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-new-func
+const isBrowser = new Function('try {return this===window;}catch(e){ return false;}');
+
+module.exports = isBrowser;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
grpc web doesn't throw cancel error on steam close that leads to stuck of the sync process

## What was done?
<!--- Describe your changes in detail -->
gRPC stream now throws grpc error on cancel in browser environment

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
platform test suite

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
