### PR TITLE
fix: wallet doesn't stop syncing on disconnect

### DIFF
--- a/src/plugins/Worker.js
+++ b/src/plugins/Worker.js
@@ -77,16 +77,27 @@ class Worker extends StandardPlugin {
     }
   }
 
-  async stopWorker(reason = null) {
-    let payloadResult = reason;
+  /**
+   * @param {Object} [options]
+   * @param {Boolean} [options.force=false]
+   * @param {Boolean} [options.reason]
+   * @returns {Promise<void>}
+   */
+  async stopWorker(options = {}) {
+    let payloadResult = options.reason;
+
     clearInterval(this.worker);
+
     this.worker = null;
     this.workerPass = 0;
     this.isWorkerRunning = false;
+
     const eventType = `WORKER/${this.name.toUpperCase()}/STOPPED`;
+
     if (this.onStop) {
-      payloadResult = await this.onStop();
+      payloadResult = await this.onStop(options);
     }
+
     this.state.started = false;
     logger.debug(JSON.stringify({ eventType, result: payloadResult }));
     this.parentEvents.emit(eventType, { type: eventType, payload: payloadResult });
@@ -107,7 +118,10 @@ class Worker extends StandardPlugin {
       try {
         payloadResult = await this.execute();
       } catch (e) {
-        await this.stopWorker(e.message);
+        await this.stopWorker({
+          reason: e.message,
+        });
+
         this.emit('error', e, {
           type: 'plugin',
           pluginType: 'worker',

--- a/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
@@ -159,15 +159,26 @@ class TransactionSyncStreamWorker extends Worker {
     this.incomingSyncPromise = this.startIncomingSync();
   }
 
-  async onStop() {
-    // Sync, will require transaction and their blockHeader to be fetched before resolving.
-    // As await onStop() is a way to wait for execution before continuing,
-    // this ensure onStop will properly let the plugin to warn about all
-    // completion of pending request.
-    if (Object.keys(this.pendingRequest).length !== 0) {
-      await sleep(200);
-      return this.onStop();
+  /**
+   * @param {Object} [options]
+   * @param {Boolean} [options.force=false]
+   * @param {Boolean} [options.reason]
+   *
+   * @returns {Promise<boolean>}
+   */
+  async onStop(options = {}) {
+    if (!options.force) {
+      // Sync, will require transaction and their blockHeader to be fetched before resolving.
+      // As await onStop() is a way to wait for execution before continuing,
+      // this ensure onStop will properly let the plugin to warn about all
+      // completion of pending request.
+      if (Object.keys(this.pendingRequest).length !== 0) {
+        await sleep(200);
+
+        return this.onStop();
+      }
     }
+
     this.syncIncomingTransactions = false;
 
     if (isBrowser()) {

--- a/src/types/Account/methods/disconnect.js
+++ b/src/types/Account/methods/disconnect.js
@@ -15,7 +15,7 @@ module.exports = async function disconnect() {
     // eslint-disable-next-line no-restricted-syntax
     for (const key of workersKey) {
       // eslint-disable-next-line no-await-in-loop
-      await this.plugins.workers[key].stopWorker();
+      await this.plugins.workers[key].stopWorker({ force: true });
     }
   }
   if (this.storage) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `Wallet#disconnet` method is called, it continues the syncing and might hang for a long period of time

## What was done?
<!--- Describe your changes in detail -->
- Add `force` option to `Worker#stopWorker` to stop without waiting for getting transaction heights
- Pass `force` option in `Account#disconnet`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
