### PR TITLE
feat: do not sync transactions if mnemonic is absent

### DIFF
--- a/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
+++ b/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
@@ -9,6 +9,8 @@ const sleep = require('../../../utils/sleep');
 const Worker = require('../../Worker');
 const isBrowser = require('../../../utils/isBrowser');
 
+const logger = require('../../../logger');
+
 class TransactionSyncStreamWorker extends Worker {
   constructor(options) {
     super({
@@ -132,7 +134,15 @@ class TransactionSyncStreamWorker extends Worker {
     // instead of usual injection process
     const {
       skipSynchronizationBeforeHeight,
+      skipSynchronization,
     } = (this.storage.store.syncOptions || {});
+
+    if (skipSynchronization) {
+      logger.debug('TransactionSyncStreamWorker - Wallet created from a new mnemonic. Sync from the best block height.');
+      const bestBlockHeight = this.storage.store.chains[this.network.toString()].blockHeight;
+      this.setLastSyncedBlockHeight(bestBlockHeight);
+      return;
+    }
 
     if (skipSynchronizationBeforeHeight) {
       this.setLastSyncedBlockHeight(

--- a/src/types/Wallet/Wallet.js
+++ b/src/types/Wallet/Wallet.js
@@ -129,6 +129,11 @@ class Wallet extends EventEmitter {
       this.store.syncOptions = {
         skipSynchronization: true,
       };
+
+      if (this.unsafeOptions.skipSynchronizationBeforeHeight) {
+        throw new Error('"unsafeOptions.skipSynchronizationBeforeHeight" will have no effect because wallet has been'
+          + ' created from the new mnemonic');
+      }
     } else if (this.unsafeOptions.skipSynchronizationBeforeHeight) {
       this.store.syncOptions = {
         skipSynchronizationBeforeHeight: this.unsafeOptions.skipSynchronizationBeforeHeight,

--- a/src/types/Wallet/Wallet.js
+++ b/src/types/Wallet/Wallet.js
@@ -79,8 +79,14 @@ class Wallet extends EventEmitter {
 
     this.network = network.toString();
 
+    let createdFromNewMnemonic = false;
     if ('mnemonic' in opts) {
-      this.fromMnemonic((opts.mnemonic === null) ? generateNewMnemonic() : opts.mnemonic);
+      let { mnemonic } = opts;
+      if (mnemonic === null) {
+        mnemonic = generateNewMnemonic();
+        createdFromNewMnemonic = true;
+      }
+      this.fromMnemonic(mnemonic);
     } else if ('seed' in opts) {
       this.fromSeed(opts.seed);
     } else if ('HDPrivateKey' in opts) {
@@ -97,6 +103,7 @@ class Wallet extends EventEmitter {
       this.fromAddress(opts.address);
     } else {
       this.fromMnemonic(generateNewMnemonic());
+      createdFromNewMnemonic = true;
     }
 
     // Notice : Most of the time, wallet id is deterministic
@@ -114,10 +121,15 @@ class Wallet extends EventEmitter {
 
     this.store = this.storage.store;
 
-    if (this.unsafeOptions.skipSynchronizationBeforeHeight) {
+    if (createdFromNewMnemonic) {
       // As it is pretty complicated to pass any of wallet options
       // to a specific plugin, using `store` as an options mediator
       // is easier.
+
+      this.store.syncOptions = {
+        skipSynchronization: true,
+      };
+    } else if (this.unsafeOptions.skipSynchronizationBeforeHeight) {
       this.store.syncOptions = {
         skipSynchronizationBeforeHeight: this.unsafeOptions.skipSynchronizationBeforeHeight,
       };


### PR DESCRIPTION
## Issue being fixed or feature implemented

This change eliminates unnecessary synchronization of transactions in case wallet has been generated from the new mnemonic


## What was done?
Check if the wallet has been generated from the new mnemonic and sync transactions from the best block (instead of block 1 or the one provided via `unsafeOptions: { skipSynchronizationBeforeHeight: <n> }`)


## How Has This Been Tested?
- Passed no mnemonic to the Wallet initialization arguments
- Ensured quick initialization time
- Hooked on account events and ensured that synchronization of the new blocks works properly


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
